### PR TITLE
Revert "Bump github.com/ostcar/topic from 0.4.1 to 0.5.0 (#105)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gomodule/redigo v1.9.3
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/ory/dockertest/v3 v3.12.0
-	github.com/ostcar/topic v0.5.0
+	github.com/ostcar/topic v0.4.1
 	github.com/shopspring/decimal v1.4.0
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/opencontainers/runc v1.2.6 h1:P7Hqg40bsMvQGCS4S7DJYhUZOISMLJOB2iGX5CO
 github.com/opencontainers/runc v1.2.6/go.mod h1:dOQeFo29xZKBNeRBI0B19mJtfHv68YgCTh1X+YphA+4=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
-github.com/ostcar/topic v0.5.0 h1:pugsn4540oHNAXYH2Ga/2cfRgLO+kaYpkwECvoqv0cI=
-github.com/ostcar/topic v0.5.0/go.mod h1:F/Ywf86Jj8NoXr0gdHhDeUGzZf4bEvHcCEuZyOaG7ko=
+github.com/ostcar/topic v0.4.1 h1:ORxFOS8BAVKRaeAr3lwYrETQAuKojCUxzWOoBn0CQTw=
+github.com/ostcar/topic v0.4.1/go.mod h1:13aefloBRYAhhb4BWjwb0hMRNx+9QSbdyCJ631ioCW4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This reverts commit b655898f8f4820c9219a10c3fdc198b974e4cc9d.