### PR TITLE
copy fields

### DIFF
--- a/datastore/flow_postgres.go
+++ b/datastore/flow_postgres.go
@@ -300,10 +300,12 @@ func createKeyList(collection string, id int) ([]dskey.Key, error) {
 	// TODO: Remove me, if the new vote service and projector service are merged
 	switch collection {
 	case "poll":
+		fields = slices.Clone(fields)
 		fields = slices.DeleteFunc(fields, func(s string) bool {
 			return s == "live_votes"
 		})
 	case "projection":
+		fields = slices.Clone(fields)
 		fields = slices.DeleteFunc(fields, func(s string) bool {
 			return s == "content"
 		})
@@ -314,7 +316,7 @@ func createKeyList(collection string, id int) ([]dskey.Key, error) {
 	for i, field := range fields {
 		keys[i], err = dskey.FromParts(collection, id, field)
 		if err != nil {
-			return nil, fmt.Errorf("creating key from parts: %w", err)
+			return nil, fmt.Errorf("creating key from parts %q, %d, %q: %w", collection, id, field, err)
 		}
 	}
 	return keys, nil


### PR DESCRIPTION
This was a tricky one.

To understand this, you can look at this: https://go.dev/play/

There is a global map with a list of strings (in our case, it is a map of all collections to there list of fields). 

When fetching an entry from this map, it creates a new slice, but the new slice points to the same data. When calling slices.DeleteFunc, it correctly manipulates the new slice, reducing its length. But it also manipulates the underlying data by moving all elements to close the gap. The last element gets cleaned. In the local list, this is correct, since the length of the slice gets also reduced. But the slice in the global map can not be manipulated. To the length-attribute stays the same. So it has am empty element at the end.

The solution copy&delete works, but is unnecessary unperformed (on a high level). But since this code will be removed soon, I think it is ok. 