### PR TITLE
Add union types for generic relations

### DIFF
--- a/datastore/dsmodels/builder.go
+++ b/datastore/dsmodels/builder.go
@@ -20,7 +20,7 @@ type builderWrapperI interface {
 }
 
 type builderPtr[T any, M any] interface {
-	lazy(ds *Fetch, id int) *M
+	lazy(ds *Fetch, id any) *M
 	*T
 }
 

--- a/datastore/dsmodels/builder.go
+++ b/datastore/dsmodels/builder.go
@@ -20,12 +20,12 @@ type builderWrapperI interface {
 	lazyAll(ctx context.Context) []any
 }
 
-type builderPtr[T any, M any] interface {
-	lazy(ds *Fetch, id any) *M
+type builderPtr[T any, M any, R any] interface {
+	lazy(ds *Fetch, id any) R
 	*T
 }
 
-type builder[C any, T builderPtr[C, M], M any] struct {
+type builder[C any, T builderPtr[C, M, R], M any, R any] struct {
 	ids      []int
 	fqids    []string
 	value    T
@@ -35,17 +35,19 @@ type builder[C any, T builderPtr[C, M], M any] struct {
 	relField string
 	many     bool
 	fetch    *Fetch
+
+	conv func(R) M
 }
 
-func (b *builder[C, T, M]) SetIds(ids []int) {
+func (b *builder[C, T, M, R]) SetIds(ids []int) {
 	b.ids = ids
 }
 
-func (b *builder[C, T, M]) SetFqids(fqids []string) {
+func (b *builder[C, T, M, R]) SetFqids(fqids []string) {
 	b.fqids = fqids
 }
 
-func (b *builder[C, T, M]) setChild(builder builderWrapperI) builderWrapperI {
+func (b *builder[C, T, M, R]) setChild(builder builderWrapperI) builderWrapperI {
 	if b.children == nil {
 		b.children = map[string]builderWrapperI{}
 	}
@@ -57,23 +59,23 @@ func (b *builder[C, T, M]) setChild(builder builderWrapperI) builderWrapperI {
 	return b.children[builder.getRelField()]
 }
 
-func (b *builder[C, T, M]) getRelField() string {
+func (b *builder[C, T, M, R]) getRelField() string {
 	return b.relField
 }
 
-func (b *builder[C, T, M]) getIDField() string {
+func (b *builder[C, T, M, R]) getIDField() string {
 	return b.idField
 }
 
-func (b *builder[C, T, M]) getMany() bool {
+func (b *builder[C, T, M, R]) getMany() bool {
 	return b.many
 }
 
-func (b *builder[C, T, M]) getParent() builderWrapperI {
+func (b *builder[C, T, M, R]) getParent() builderWrapperI {
 	return b.parent
 }
 
-func (b *builder[C, T, M]) lazyAll(ctx context.Context) []any {
+func (b *builder[C, T, M, R]) lazyAll(ctx context.Context) []any {
 	items := []any{}
 	for _, id := range b.ids {
 		items = append(items, b.value.lazy(b.fetch, id))
@@ -86,7 +88,7 @@ func (b *builder[C, T, M]) lazyAll(ctx context.Context) []any {
 	return items
 }
 
-func (b *builder[C, T, M]) Preload(rel builderWrapperI) {
+func (b *builder[C, T, M, R]) Preload(rel builderWrapperI) {
 	children := []builderWrapperI{}
 	for rel != b && rel != nil && rel.getRelField() != "" {
 		children = append([]builderWrapperI{rel}, children...)
@@ -141,7 +143,7 @@ type childInfo struct {
 	targetField reflect.Value
 }
 
-func (b *builder[C, T, M]) prepareChildren(ctx context.Context, parents ...any) []childInfo {
+func (b *builder[C, T, M, R]) prepareChildren(ctx context.Context, parents ...any) []childInfo {
 	childInfos := make([]childInfo, 0, len(b.children))
 	for _, parent := range parents {
 		rParent := reflect.ValueOf(parent).Elem()
@@ -211,7 +213,7 @@ func bulkLoadChildren(ctx context.Context, fetch *Fetch, requests []loadRequest)
 	return nil
 }
 
-func (b *builder[C, T, M]) loadChildren(ctx context.Context, parents ...any) error {
+func (b *builder[C, T, M, R]) loadChildren(ctx context.Context, parents ...any) error {
 	if b.children == nil {
 		return nil
 	}
@@ -222,7 +224,7 @@ func (b *builder[C, T, M]) loadChildren(ctx context.Context, parents ...any) err
 	}})
 }
 
-func (b *builder[C, T, M]) First(ctx context.Context) (M, error) {
+func (b *builder[C, T, M, R]) First(ctx context.Context) (M, error) {
 	c := b.value.lazy(b.fetch, b.ids[0])
 
 	if err := b.fetch.Execute(ctx); err != nil {
@@ -235,11 +237,11 @@ func (b *builder[C, T, M]) First(ctx context.Context) (M, error) {
 		return zero, err
 	}
 
-	return *c, nil
+	return b.conv(c), nil
 }
 
-func (b *builder[C, T, M]) Get(ctx context.Context) ([]M, error) {
-	itemPtrs := make([]*M, len(b.ids))
+func (b *builder[C, T, M, R]) Get(ctx context.Context) ([]M, error) {
+	itemPtrs := make([]R, len(b.ids))
 	for i, id := range b.ids {
 		itemPtrs[i] = b.value.lazy(b.fetch, id)
 	}
@@ -253,7 +255,7 @@ func (b *builder[C, T, M]) Get(ctx context.Context) ([]M, error) {
 		if err := b.loadChildren(ctx, el); err != nil {
 			return []M{}, err
 		}
-		items[i] = *el
+		items[i] = b.conv(el)
 	}
 
 	return items, nil

--- a/datastore/dsmodels/builder.go
+++ b/datastore/dsmodels/builder.go
@@ -9,6 +9,7 @@ import (
 
 type builderWrapperI interface {
 	SetIds(ids []int)
+	SetFqids(fqids []string)
 	setChild(builder builderWrapperI) builderWrapperI
 	getParent() builderWrapperI
 	getIDField() string
@@ -26,6 +27,7 @@ type builderPtr[T any, M any] interface {
 
 type builder[C any, T builderPtr[C, M], M any] struct {
 	ids      []int
+	fqids    []string
 	value    T
 	parent   builderWrapperI
 	children map[string]builderWrapperI
@@ -37,6 +39,10 @@ type builder[C any, T builderPtr[C, M], M any] struct {
 
 func (b *builder[C, T, M]) SetIds(ids []int) {
 	b.ids = ids
+}
+
+func (b *builder[C, T, M]) SetFqids(fqids []string) {
+	b.fqids = fqids
 }
 
 func (b *builder[C, T, M]) setChild(builder builderWrapperI) builderWrapperI {
@@ -72,6 +78,11 @@ func (b *builder[C, T, M]) lazyAll(ctx context.Context) []any {
 	for _, id := range b.ids {
 		items = append(items, b.value.lazy(b.fetch, id))
 	}
+
+	for _, id := range b.fqids {
+		items = append(items, b.value.lazy(b.fetch, id))
+	}
+
 	return items
 }
 
@@ -89,12 +100,15 @@ func (b *builder[C, T, M]) Preload(rel builderWrapperI) {
 	}
 }
 
-func getRelationIds(idField reflect.Value, targetField reflect.Value, many bool) []int {
+func getRelationIds(idField reflect.Value, targetField reflect.Value, many bool) ([]int, []string) {
 	ids := []int{}
+	fqids := []string{}
 	if many {
 		ids = idField.Interface().([]int)
 	} else if idField.Kind() == reflect.Int {
 		ids = append(ids, int(idField.Int()))
+	} else if idField.Kind() == reflect.String {
+		fqids = append(fqids, string(idField.String()))
 	} else if idField.Type().Name() == "Maybe[int]" {
 		relMaybeType := targetField.Type().Elem()
 		relValue := reflect.New(relMaybeType)
@@ -107,7 +121,7 @@ func getRelationIds(idField reflect.Value, targetField reflect.Value, many bool)
 		}
 	}
 
-	return ids
+	return ids, fqids
 }
 
 func setRelationField(idField reflect.Value, targetField reflect.Value, item any, many bool) {
@@ -134,8 +148,9 @@ func (b *builder[C, T, M]) prepareChildren(ctx context.Context, parents ...any) 
 		for _, child := range b.children {
 			idField := rParent.FieldByName(child.getIDField())
 			targetField := rParent.FieldByName(child.getRelField())
-			ids := getRelationIds(idField, targetField, child.getMany())
+			ids, fqids := getRelationIds(idField, targetField, child.getMany())
 			child.SetIds(ids)
+			child.SetFqids(fqids)
 			items := child.lazyAll(ctx)
 			childInfos = append(childInfos, childInfo{
 				child:       child,

--- a/datastore/dsmodels/fetch_test.go
+++ b/datastore/dsmodels/fetch_test.go
@@ -1,6 +1,7 @@
 package dsmodels_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/OpenSlides/openslides-go/datastore/dsmock"
@@ -244,5 +245,37 @@ func TestRequestSinglePreloadMulti(t *testing.T) {
 
 	if res.ListOfSpeakers.ContentObjectID != "topic/1" {
 		t.Errorf("res.ListOfSpeakers.ContentObjectID = %s, expected topic/1", res.ListOfSpeakers.ContentObjectID)
+	}
+}
+
+func TestPolymorphicPreload(t *testing.T) {
+	ds := dsmodels.New(dsmock.Stub(dsmock.YAMLData(`---
+	topic/1:
+		sequential_number: 1
+		title: foo
+		meeting_id: 1
+		agenda_item_id: 1
+		list_of_speakers_id: 1
+	agenda_item/1/content_object_id: topic/1
+	agenda_item/1/meeting_id: 1
+	list_of_speakers/1:
+		sequential_number: 1
+		content_object_id: topic/1
+		meeting_id: 1
+	`)))
+
+	tQ := ds.AgendaItem(1)
+	res, err := tQ.Preload(tQ.ContentObject()).First(t.Context())
+	if err != nil {
+		t.Errorf("Topic 1 with agenda item returned unexpected error: %v", err)
+	}
+
+	topic, isTopic := res.ContentObject.(*dsmodels.Topic)
+	if !isTopic {
+		t.Errorf("type of res.ContentObject = %s, expected *dsmodels.Topic", reflect.TypeOf(res.ContentObject))
+	}
+
+	if topic.Title != "foo" {
+		t.Errorf("res.ContentObject.Title = %s, expected 'foo'", topic.Title)
 	}
 }

--- a/datastore/dsmodels/gen_models/collection.go.tmpl
+++ b/datastore/dsmodels/gen_models/collection.go.tmpl
@@ -70,6 +70,7 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 				return nil
 			}
 
+			var iface {{.Type}}
 			switch collection {
 			{{ $genericTypesLc := .GenericTypesLc }}
 			{{ $genericTypesCc := .GenericTypesCc }}
@@ -82,7 +83,8 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 					},
 				}
 				result := builder.lazy(ds, intId)
-				return (*{{$type}})(unsafe.Pointer(result))
+				iface = result
+				return &iface
 			{{ end }}
 			}
 					

--- a/datastore/dsmodels/gen_models/collection.go.tmpl
+++ b/datastore/dsmodels/gen_models/collection.go.tmpl
@@ -1,3 +1,15 @@
+{{ range .Relations }}
+	{{ if .IsGeneric }}
+		type {{ .Type }} interface {
+    		is{{ .Type }}()
+		}
+
+		{{ $type := .Type }}
+		{{ range $index, $element := .GenericTypes }}
+		func (*{{ $element }}) is{{ $type }}() {}{{ end }}
+	{{ end }}
+{{ end }}
+
 // {{.GoName}} has all fields from {{.CollectionName}}.
 type {{.GoName}} struct{
     {{- range .Fields}}
@@ -25,21 +37,25 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
     return b
 }
 
-{{ range .Relations}}
-func (b *{{$.GoNameLc}}Builder) {{.MethodName}}() *{{.TypeLc}}Builder {
-	return &{{.TypeLc}}Builder{
-		builder: builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]{
-			fetch: b.fetch,
-			parent: b,
-			idField: "{{.FieldName}}",
-			relField: "{{.MethodName}}",
-            {{- if .IsList}}
-            many: true,
-	        {{- end}}
-		},
-	}
-}
-{{end}}
+{{ range .Relations }}
+	{{ if .IsGeneric }}
+		// TODO: func (b *{{$.GoNameLc}}Builder) {{.MethodName}}()
+	{{ else }}
+		func (b *{{$.GoNameLc}}Builder) {{.MethodName}}() *{{.TypeLc}}Builder {
+			return &{{.TypeLc}}Builder{
+				builder: builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]{
+					fetch: b.fetch,
+					parent: b,
+					idField: "{{.FieldName}}",
+					relField: "{{.MethodName}}",
+            		{{- if .IsList}}
+            		many: true,
+	        		{{- end}}
+				},
+			}
+		}
+	{{ end }}
+{{ end }}
 
 func (r *Fetch){{.GoName}}(ids... int) *{{.GoNameLc}}Builder {
 	return &{{.GoNameLc}}Builder{

--- a/datastore/dsmodels/gen_models/collection.go.tmpl
+++ b/datastore/dsmodels/gen_models/collection.go.tmpl
@@ -9,7 +9,7 @@ type {{.GoName}} struct{
 }
 
 type {{.GoNameLc}}Builder struct{
-    builder[{{.GoNameLc}}Builder, *{{.GoNameLc}}Builder, {{.GoName}}]
+  builder[{{.GoNameLc}}Builder, *{{.GoNameLc}}Builder, {{.GoName}}, *{{.GoName}}]
 }
 
 func (b *{{.GoNameLc}}Builder)lazy(ds *Fetch, idI any) *{{.GoName}} {
@@ -29,14 +29,19 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 {{ range .Relations }}
 	func (b *{{$.GoNameLc}}Builder) {{.MethodName}}() *{{.TypeLc}}Builder {
 		return &{{.TypeLc}}Builder{
-			builder: builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]{
+			builder: builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}, {{ if not .IsGeneric }}*{{ end }}{{.Type}}]{
 				fetch: b.fetch,
 				parent: b,
 				idField: "{{.FieldName}}",
 				relField: "{{.MethodName}}",
-            	{{- if .IsList}}
-            	many: true,
-	        	{{- end}}
+        {{- if .IsList}}
+          many: true,
+	      {{- end}}
+				{{- if .IsGeneric }}
+	      	conv: func(u {{.Type}}) {{.Type}} { return u },
+				{{- else }}
+	      	conv: func(p *{{.Type}}) {{.Type}} { return *p },
+				{{- end }}
 			},
 		}
 	}
@@ -51,10 +56,10 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 		func (*{{ $element }}) is{{ $type }}() {}{{ end }}
 
 		type {{.TypeLc}}Builder struct {
-			builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]
+			builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}, {{.Type}}]
 		}
 
-		func (b *{{.TypeLc}}Builder) lazy(ds *Fetch, id any) *{{.Type}} {
+		func (b *{{.TypeLc}}Builder) lazy(ds *Fetch, id any) {{.Type}} {
 			fqid, ok := id.(string)
 			if !ok {
 				return nil
@@ -70,22 +75,20 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 				return nil
 			}
 
-			var iface {{.Type}}
 			switch collection {
-			{{ $genericTypesLc := .GenericTypesLc }}
-			{{ $genericTypesCc := .GenericTypesCc }}
-			{{ range $i, $gType := .GenericTypes }}
+			{{- $genericTypesLc := .GenericTypesLc }}
+			{{- $genericTypesCc := .GenericTypesCc }}
+			{{- range $i, $gType := .GenericTypes }}
 			case "{{ index $genericTypesCc $i }}":
-				{{ $typeLc := index $genericTypesLc $i }}
+				{{- $typeLc := index $genericTypesLc $i }}
 				builder := &{{$typeLc}}Builder{
-					builder: builder[{{$typeLc}}Builder, *{{$typeLc}}Builder, {{$gType}}]{
+					builder: builder[{{$typeLc}}Builder, *{{$typeLc}}Builder, {{$gType}}, *{{$gType}}]{
 						fetch: ds,
+	    			conv: func(p *{{$gType}}) {{$gType}} { return *p },
 					},
 				}
-				result := builder.lazy(ds, intId)
-				iface = result
-				return &iface
-			{{ end }}
+				return builder.lazy(ds, intId)
+			{{- end }}
 			}
 					
 			return nil
@@ -100,9 +103,10 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 
 func (r *Fetch){{.GoName}}(ids... int) *{{.GoNameLc}}Builder {
 	return &{{.GoNameLc}}Builder{
-		builder: builder[{{.GoNameLc}}Builder, *{{.GoNameLc}}Builder, {{.GoName}}]{
+		builder: builder[{{.GoNameLc}}Builder, *{{.GoNameLc}}Builder, {{.GoName}}, *{{.GoName}}]{
 			ids: ids,
 			fetch: r,
+	    conv: func(p *{{.GoName}}) {{.GoName}} { return *p },
 		},
 	}
 }

--- a/datastore/dsmodels/gen_models/collection.go.tmpl
+++ b/datastore/dsmodels/gen_models/collection.go.tmpl
@@ -1,15 +1,3 @@
-{{ range .Relations }}
-	{{ if .IsGeneric }}
-		type {{ .Type }} interface {
-    		is{{ .Type }}()
-		}
-
-		{{ $type := .Type }}
-		{{ range $index, $element := .GenericTypes }}
-		func (*{{ $element }}) is{{ $type }}() {}{{ end }}
-	{{ end }}
-{{ end }}
-
 // {{.GoName}} has all fields from {{.CollectionName}}.
 type {{.GoName}} struct{
     {{- range .Fields}}
@@ -24,7 +12,8 @@ type {{.GoNameLc}}Builder struct{
     builder[{{.GoNameLc}}Builder, *{{.GoNameLc}}Builder, {{.GoName}}]
 }
 
-func (b *{{.GoNameLc}}Builder)lazy(ds *Fetch, id int) *{{.GoName}} {
+func (b *{{.GoNameLc}}Builder)lazy(ds *Fetch, idI any) *{{.GoName}} {
+		id := idI.(int)
     c := {{.GoName}}{}
     {{- range .Fields}}
     ds.{{.FetchName}}(id).Lazy(&c.{{.Name}})
@@ -38,21 +27,71 @@ func (b *{{.GoNameLc}}Builder) Preload(rel builderWrapperI) *{{.GoNameLc}}Builde
 }
 
 {{ range .Relations }}
+	func (b *{{$.GoNameLc}}Builder) {{.MethodName}}() *{{.TypeLc}}Builder {
+		return &{{.TypeLc}}Builder{
+			builder: builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]{
+				fetch: b.fetch,
+				parent: b,
+				idField: "{{.FieldName}}",
+				relField: "{{.MethodName}}",
+            	{{- if .IsList}}
+            	many: true,
+	        	{{- end}}
+			},
+		}
+	}
+
 	{{ if .IsGeneric }}
-		// TODO: func (b *{{$.GoNameLc}}Builder) {{.MethodName}}()
-	{{ else }}
-		func (b *{{$.GoNameLc}}Builder) {{.MethodName}}() *{{.TypeLc}}Builder {
-			return &{{.TypeLc}}Builder{
-				builder: builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]{
-					fetch: b.fetch,
-					parent: b,
-					idField: "{{.FieldName}}",
-					relField: "{{.MethodName}}",
-            		{{- if .IsList}}
-            		many: true,
-	        		{{- end}}
-				},
+		type {{ .Type }} interface {
+    		is{{ .Type }}()
+		}
+
+		{{ $type := .Type }}
+		{{ range $index, $element := .GenericTypes }}
+		func (*{{ $element }}) is{{ $type }}() {}{{ end }}
+
+		type {{.TypeLc}}Builder struct {
+			builder[{{.TypeLc}}Builder, *{{.TypeLc}}Builder, {{.Type}}]
+		}
+
+		func (b *{{.TypeLc}}Builder) lazy(ds *Fetch, id any) *{{.Type}} {
+			fqid, ok := id.(string)
+			if !ok {
+				return nil
 			}
+			
+			collection, idStr, ok := strings.Cut(fqid, "/")
+			if !ok {
+				return nil
+			}
+			
+			intId, err := strconv.Atoi(idStr)
+			if err != nil {
+				return nil
+			}
+
+			switch collection {
+			{{ $genericTypesLc := .GenericTypesLc }}
+			{{ $genericTypesCc := .GenericTypesCc }}
+			{{ range $i, $gType := .GenericTypes }}
+			case "{{ index $genericTypesCc $i }}":
+				{{ $typeLc := index $genericTypesLc $i }}
+				builder := &{{$typeLc}}Builder{
+					builder: builder[{{$typeLc}}Builder, *{{$typeLc}}Builder, {{$gType}}]{
+						fetch: ds,
+					},
+				}
+				result := builder.lazy(ds, intId)
+				return (*{{$type}})(unsafe.Pointer(result))
+			{{ end }}
+			}
+					
+			return nil
+		}
+
+		func (b *{{.TypeLc}}Builder) Preload(rel builderWrapperI) *{{.TypeLc}}Builder {
+			b.builder.Preload(rel)
+			return b
 		}
 	{{ end }}
 {{ end }}

--- a/datastore/dsmodels/gen_models/header.go.tmpl
+++ b/datastore/dsmodels/gen_models/header.go.tmpl
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
-	"unsafe"
 
   "github.com/OpenSlides/openslides-go/datastore/dsfetch"
 	"github.com/shopspring/decimal"

--- a/datastore/dsmodels/gen_models/header.go.tmpl
+++ b/datastore/dsmodels/gen_models/header.go.tmpl
@@ -3,6 +3,10 @@ package dsmodels
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
+	"unsafe"
+
   "github.com/OpenSlides/openslides-go/datastore/dsfetch"
 	"github.com/shopspring/decimal"
 )

--- a/datastore/dsmodels/gen_models/main.go
+++ b/datastore/dsmodels/gen_models/main.go
@@ -178,9 +178,12 @@ type CollectionField struct {
 // CollectionRelation is one Relation, needed for method generation.
 type CollectionRelation struct {
 	ResultType      string
+	IsGeneric       bool
 	IsList          bool
 	Type            string
 	TypeLc          string
+	GenericTypes    []string
+	GenericTypesLc  []string
 	FieldName       string
 	MethodName      string
 	StructFieldName string
@@ -212,20 +215,32 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 				continue
 			}
 
-			if strings.Contains(collectionField.Type, "generic") {
-				// TODO: Add generic
-				//fmt.Println(collectionName, fieldName)
-				continue
+			isGeneric := strings.Contains(collectionField.Type, "generic")
+
+			genericTypes := []string{}
+			genericTypesLc := []string{}
+			var resultType string
+			toType := goName(relation.ToCollections()[0].Collection)
+			if isGeneric {
+				toType = fmt.Sprintf("%s%sUnion", colGoName, withoutID(goName(fieldName)))
+				for _, col := range relation.ToCollections() {
+					colName := goName(col.Collection)
+					genericTypes = append(genericTypes, colName)
+					genericTypesLc = append(genericTypesLc, string(colName[0]+32)+string(colName[1:]))
+				}
 			}
 
-			toType := goName(relation.ToCollections()[0].Collection)
 			toTypeLc := string(toType[0]+32) + string(toType[1:])
 
-			resultType := fmt.Sprintf("*%s", toType)
+			resultType = fmt.Sprintf("*%s", toType)
 			if !relation.List() && !collectionField.Required {
 				resultType = fmt.Sprintf("*dsfetch.Maybe[%s]", toType)
 			}
 			if relation.List() {
+				if isGeneric {
+					continue
+				}
+
 				resultType = fmt.Sprintf("[]%s", toType)
 			}
 
@@ -236,12 +251,15 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 				col.Relations,
 				CollectionRelation{
 					ResultType:      resultType,
+					IsGeneric:       isGeneric,
 					IsList:          relation.List(),
 					FieldName:       goName(fieldName),
 					MethodName:      methodName,
 					StructFieldName: structFieldName,
 					Type:            toType,
 					TypeLc:          toTypeLc,
+					GenericTypes:    genericTypes,
+					GenericTypesLc:  genericTypesLc,
 					Required:        collectionField.Required,
 				},
 			)

--- a/datastore/dsmodels/gen_models/main.go
+++ b/datastore/dsmodels/gen_models/main.go
@@ -240,6 +240,9 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 			if !relation.List() && !collectionField.Required {
 				resultType = fmt.Sprintf("*dsfetch.Maybe[%s]", toType)
 			}
+			if isGeneric {
+				resultType = fmt.Sprintf("%s", toType)
+			}
 			if relation.List() {
 				if isGeneric {
 					// TODO: Generic lists are currently skipped

--- a/datastore/dsmodels/gen_models/main.go
+++ b/datastore/dsmodels/gen_models/main.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -28,6 +29,9 @@ var tmplHeader string
 
 //go:embed collection.go.tmpl
 var tmplCollection string
+
+//go:embed generic_union.go.tmpl
+var tmplGenericUnion string
 
 func main() {
 	if err := run(os.Stdout); err != nil {
@@ -184,6 +188,7 @@ type CollectionRelation struct {
 	TypeLc          string
 	GenericTypes    []string
 	GenericTypesLc  []string
+	GenericTypesCc  []string
 	FieldName       string
 	MethodName      string
 	StructFieldName string
@@ -219,6 +224,7 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 
 			genericTypes := []string{}
 			genericTypesLc := []string{}
+			genericTypesCc := []string{}
 			var resultType string
 			toType := goName(relation.ToCollections()[0].Collection)
 			if isGeneric {
@@ -227,6 +233,7 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 					colName := goName(col.Collection)
 					genericTypes = append(genericTypes, colName)
 					genericTypesLc = append(genericTypesLc, string(colName[0]+32)+string(colName[1:]))
+					genericTypesCc = append(genericTypesCc, col.Collection)
 				}
 			}
 
@@ -238,6 +245,7 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 			}
 			if relation.List() {
 				if isGeneric {
+					// TODO: Generic lists are currently skipped
 					continue
 				}
 
@@ -260,6 +268,7 @@ func toCollections(raw map[string]collection.Collection) []Collection {
 					TypeLc:          toTypeLc,
 					GenericTypes:    genericTypes,
 					GenericTypesLc:  genericTypesLc,
+					GenericTypesCc:  genericTypesCc,
 					Required:        collectionField.Required,
 				},
 			)
@@ -297,6 +306,15 @@ func goName(name string) string {
 
 	name = strings.ReplaceAll(name, "Id", "ID")
 	return name
+}
+
+func dbName(inputCamelCaseStr string) string {
+	re := regexp.MustCompile(`[A-z][^A-Z]*`)
+	parts := re.FindAllString(inputCamelCaseStr, -1)
+	for index := range parts {
+		parts[index] = strings.ToLower(parts[index])
+	}
+	return strings.Join(parts, "_")
 }
 
 func withoutID(in string) string {

--- a/datastore/dsmodels/gen_models/main.go
+++ b/datastore/dsmodels/gen_models/main.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -306,15 +305,6 @@ func goName(name string) string {
 
 	name = strings.ReplaceAll(name, "Id", "ID")
 	return name
-}
-
-func dbName(inputCamelCaseStr string) string {
-	re := regexp.MustCompile(`[A-z][^A-Z]*`)
-	parts := re.FindAllString(inputCamelCaseStr, -1)
-	for index := range parts {
-		parts[index] = strings.ToLower(parts[index])
-	}
-	return strings.Join(parts, "_")
 }
 
 func withoutID(in string) string {

--- a/datastore/dsmodels/gen_models/main.go
+++ b/datastore/dsmodels/gen_models/main.go
@@ -30,9 +30,6 @@ var tmplHeader string
 //go:embed collection.go.tmpl
 var tmplCollection string
 
-//go:embed generic_union.go.tmpl
-var tmplGenericUnion string
-
 func main() {
 	if err := run(os.Stdout); err != nil {
 		log.Fatalf("Error: %v", err)

--- a/datastore/dsmodels/models_generated.go
+++ b/datastore/dsmodels/models_generated.go
@@ -22,7 +22,7 @@ type ActionWorker struct {
 }
 
 type actionWorkerBuilder struct {
-	builder[actionWorkerBuilder, *actionWorkerBuilder, ActionWorker]
+	builder[actionWorkerBuilder, *actionWorkerBuilder, ActionWorker, *ActionWorker]
 }
 
 func (b *actionWorkerBuilder) lazy(ds *Fetch, idI any) *ActionWorker {
@@ -45,9 +45,10 @@ func (b *actionWorkerBuilder) Preload(rel builderWrapperI) *actionWorkerBuilder 
 
 func (r *Fetch) ActionWorker(ids ...int) *actionWorkerBuilder {
 	return &actionWorkerBuilder{
-		builder: builder[actionWorkerBuilder, *actionWorkerBuilder, ActionWorker]{
+		builder: builder[actionWorkerBuilder, *actionWorkerBuilder, ActionWorker, *ActionWorker]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ActionWorker) ActionWorker { return *p },
 		},
 	}
 }
@@ -71,7 +72,7 @@ type AgendaItem struct {
 	Type            string
 	Weight          int
 	ChildList       []AgendaItem
-	ContentObject   *AgendaItemContentObjectUnion
+	ContentObject   AgendaItemContentObjectUnion
 	Meeting         *Meeting
 	Parent          *dsfetch.Maybe[AgendaItem]
 	ProjectionList  []Projection
@@ -79,7 +80,7 @@ type AgendaItem struct {
 }
 
 type agendaItemBuilder struct {
-	builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]
+	builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]
 }
 
 func (b *agendaItemBuilder) lazy(ds *Fetch, idI any) *AgendaItem {
@@ -111,23 +112,25 @@ func (b *agendaItemBuilder) Preload(rel builderWrapperI) *agendaItemBuilder {
 
 func (b *agendaItemBuilder) ChildList() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChildIDs",
 			relField: "ChildList",
 			many:     true,
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *agendaItemBuilder) ContentObject() *agendaItemContentObjectUnionBuilder {
 	return &agendaItemContentObjectUnionBuilder{
-		builder: builder[agendaItemContentObjectUnionBuilder, *agendaItemContentObjectUnionBuilder, AgendaItemContentObjectUnion]{
+		builder: builder[agendaItemContentObjectUnionBuilder, *agendaItemContentObjectUnionBuilder, AgendaItemContentObjectUnion, AgendaItemContentObjectUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ContentObjectID",
 			relField: "ContentObject",
+			conv:     func(u AgendaItemContentObjectUnion) AgendaItemContentObjectUnion { return u },
 		},
 	}
 }
@@ -142,10 +145,10 @@ func (*Assignment) isAgendaItemContentObjectUnion()  {}
 func (*Topic) isAgendaItemContentObjectUnion()       {}
 
 type agendaItemContentObjectUnionBuilder struct {
-	builder[agendaItemContentObjectUnionBuilder, *agendaItemContentObjectUnionBuilder, AgendaItemContentObjectUnion]
+	builder[agendaItemContentObjectUnionBuilder, *agendaItemContentObjectUnionBuilder, AgendaItemContentObjectUnion, AgendaItemContentObjectUnion]
 }
 
-func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaItemContentObjectUnion {
+func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) AgendaItemContentObjectUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -161,53 +164,39 @@ func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaIte
 		return nil
 	}
 
-	var iface AgendaItemContentObjectUnion
 	switch collection {
-
 	case "motion":
-
 		builder := &motionBuilder{
-			builder: builder[motionBuilder, *motionBuilder, Motion]{
+			builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 				fetch: ds,
+				conv:  func(p *Motion) Motion { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "motion_block":
-
 		builder := &motionBlockBuilder{
-			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]{
 				fetch: ds,
+				conv:  func(p *MotionBlock) MotionBlock { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "assignment":
-
 		builder := &assignmentBuilder{
-			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 				fetch: ds,
+				conv:  func(p *Assignment) Assignment { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "topic":
-
 		builder := &topicBuilder{
-			builder: builder[topicBuilder, *topicBuilder, Topic]{
+			builder: builder[topicBuilder, *topicBuilder, Topic, *Topic]{
 				fetch: ds,
+				conv:  func(p *Topic) Topic { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -220,55 +209,60 @@ func (b *agendaItemContentObjectUnionBuilder) Preload(rel builderWrapperI) *agen
 
 func (b *agendaItemBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *agendaItemBuilder) Parent() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ParentID",
 			relField: "Parent",
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *agendaItemBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *agendaItemBuilder) TagList() *tagBuilder {
 	return &tagBuilder{
-		builder: builder[tagBuilder, *tagBuilder, Tag]{
+		builder: builder[tagBuilder, *tagBuilder, Tag, *Tag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TagIDs",
 			relField: "TagList",
 			many:     true,
+			conv:     func(p *Tag) Tag { return *p },
 		},
 	}
 }
 
 func (r *Fetch) AgendaItem(ids ...int) *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
@@ -304,7 +298,7 @@ type Assignment struct {
 }
 
 type assignmentBuilder struct {
-	builder[assignmentBuilder, *assignmentBuilder, Assignment]
+	builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]
 }
 
 func (b *assignmentBuilder) lazy(ds *Fetch, idI any) *Assignment {
@@ -337,114 +331,124 @@ func (b *assignmentBuilder) Preload(rel builderWrapperI) *assignmentBuilder {
 
 func (b *assignmentBuilder) AgendaItem() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AgendaItemID",
 			relField: "AgendaItem",
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) AttachmentMeetingMediafileList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AttachmentMeetingMediafileIDs",
 			relField: "AttachmentMeetingMediafileList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) CandidateList() *assignmentCandidateBuilder {
 	return &assignmentCandidateBuilder{
-		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate]{
+		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate, *AssignmentCandidate]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CandidateIDs",
 			relField: "CandidateList",
 			many:     true,
+			conv:     func(p *AssignmentCandidate) AssignmentCandidate { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) HistoryEntryList() *historyEntryBuilder {
 	return &historyEntryBuilder{
-		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]{
+		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HistoryEntryIDs",
 			relField: "HistoryEntryList",
 			many:     true,
+			conv:     func(p *HistoryEntry) HistoryEntry { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) PollList() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollIDs",
 			relField: "PollList",
 			many:     true,
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *assignmentBuilder) TagList() *tagBuilder {
 	return &tagBuilder{
-		builder: builder[tagBuilder, *tagBuilder, Tag]{
+		builder: builder[tagBuilder, *tagBuilder, Tag, *Tag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TagIDs",
 			relField: "TagList",
 			many:     true,
+			conv:     func(p *Tag) Tag { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Assignment(ids ...int) *assignmentBuilder {
 	return &assignmentBuilder{
-		builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+		builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Assignment) Assignment { return *p },
 		},
 	}
 }
@@ -462,7 +466,7 @@ type AssignmentCandidate struct {
 }
 
 type assignmentCandidateBuilder struct {
-	builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate]
+	builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate, *AssignmentCandidate]
 }
 
 func (b *assignmentCandidateBuilder) lazy(ds *Fetch, idI any) *AssignmentCandidate {
@@ -483,42 +487,46 @@ func (b *assignmentCandidateBuilder) Preload(rel builderWrapperI) *assignmentCan
 
 func (b *assignmentCandidateBuilder) Assignment() *assignmentBuilder {
 	return &assignmentBuilder{
-		builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+		builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AssignmentID",
 			relField: "Assignment",
+			conv:     func(p *Assignment) Assignment { return *p },
 		},
 	}
 }
 
 func (b *assignmentCandidateBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *assignmentCandidateBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (r *Fetch) AssignmentCandidate(ids ...int) *assignmentCandidateBuilder {
 	return &assignmentCandidateBuilder{
-		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate]{
+		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate, *AssignmentCandidate]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *AssignmentCandidate) AssignmentCandidate { return *p },
 		},
 	}
 }
@@ -539,7 +547,7 @@ type ChatGroup struct {
 }
 
 type chatGroupBuilder struct {
-	builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]
+	builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup, *ChatGroup]
 }
 
 func (b *chatGroupBuilder) lazy(ds *Fetch, idI any) *ChatGroup {
@@ -562,56 +570,61 @@ func (b *chatGroupBuilder) Preload(rel builderWrapperI) *chatGroupBuilder {
 
 func (b *chatGroupBuilder) ChatMessageList() *chatMessageBuilder {
 	return &chatMessageBuilder{
-		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage]{
+		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage, *ChatMessage]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChatMessageIDs",
 			relField: "ChatMessageList",
 			many:     true,
+			conv:     func(p *ChatMessage) ChatMessage { return *p },
 		},
 	}
 }
 
 func (b *chatGroupBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *chatGroupBuilder) ReadGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReadGroupIDs",
 			relField: "ReadGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *chatGroupBuilder) WriteGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "WriteGroupIDs",
 			relField: "WriteGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (r *Fetch) ChatGroup(ids ...int) *chatGroupBuilder {
 	return &chatGroupBuilder{
-		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]{
+		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup, *ChatGroup]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ChatGroup) ChatGroup { return *p },
 		},
 	}
 }
@@ -630,7 +643,7 @@ type ChatMessage struct {
 }
 
 type chatMessageBuilder struct {
-	builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage]
+	builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage, *ChatMessage]
 }
 
 func (b *chatMessageBuilder) lazy(ds *Fetch, idI any) *ChatMessage {
@@ -652,42 +665,46 @@ func (b *chatMessageBuilder) Preload(rel builderWrapperI) *chatMessageBuilder {
 
 func (b *chatMessageBuilder) ChatGroup() *chatGroupBuilder {
 	return &chatGroupBuilder{
-		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]{
+		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup, *ChatGroup]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChatGroupID",
 			relField: "ChatGroup",
+			conv:     func(p *ChatGroup) ChatGroup { return *p },
 		},
 	}
 }
 
 func (b *chatMessageBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *chatMessageBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (r *Fetch) ChatMessage(ids ...int) *chatMessageBuilder {
 	return &chatMessageBuilder{
-		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage]{
+		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage, *ChatMessage]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ChatMessage) ChatMessage { return *p },
 		},
 	}
 }
@@ -727,7 +744,7 @@ type Committee struct {
 }
 
 type committeeBuilder struct {
-	builder[committeeBuilder, *committeeBuilder, Committee]
+	builder[committeeBuilder, *committeeBuilder, Committee, *Committee]
 }
 
 func (b *committeeBuilder) lazy(ds *Fetch, idI any) *Committee {
@@ -760,162 +777,176 @@ func (b *committeeBuilder) Preload(rel builderWrapperI) *committeeBuilder {
 
 func (b *committeeBuilder) AllChildList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AllChildIDs",
 			relField: "AllChildList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) AllParentList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AllParentIDs",
 			relField: "AllParentList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) ChildList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChildIDs",
 			relField: "ChildList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) DefaultMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultMeetingID",
 			relField: "DefaultMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) ForwardToCommitteeList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ForwardToCommitteeIDs",
 			relField: "ForwardToCommitteeList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) ManagerList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ManagerIDs",
 			relField: "ManagerList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) MeetingList() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingIDs",
 			relField: "MeetingList",
 			many:     true,
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) NativeUserList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "NativeUserIDs",
 			relField: "NativeUserList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) Organization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationID",
 			relField: "Organization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) OrganizationTagList() *organizationTagBuilder {
 	return &organizationTagBuilder{
-		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag]{
+		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag, *OrganizationTag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationTagIDs",
 			relField: "OrganizationTagList",
 			many:     true,
+			conv:     func(p *OrganizationTag) OrganizationTag { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) Parent() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ParentID",
 			relField: "Parent",
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) ReceiveForwardingsFromCommitteeList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReceiveForwardingsFromCommitteeIDs",
 			relField: "ReceiveForwardingsFromCommitteeList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *committeeBuilder) UserList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UserIDs",
 			relField: "UserList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Committee(ids ...int) *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Committee) Committee { return *p },
 		},
 	}
 }
@@ -931,7 +962,7 @@ type Gender struct {
 }
 
 type genderBuilder struct {
-	builder[genderBuilder, *genderBuilder, Gender]
+	builder[genderBuilder, *genderBuilder, Gender, *Gender]
 }
 
 func (b *genderBuilder) lazy(ds *Fetch, idI any) *Gender {
@@ -951,32 +982,35 @@ func (b *genderBuilder) Preload(rel builderWrapperI) *genderBuilder {
 
 func (b *genderBuilder) Organization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationID",
 			relField: "Organization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (b *genderBuilder) UserList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UserIDs",
 			relField: "UserList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Gender(ids ...int) *genderBuilder {
 	return &genderBuilder{
-		builder: builder[genderBuilder, *genderBuilder, Gender]{
+		builder: builder[genderBuilder, *genderBuilder, Gender, *Gender]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Gender) Gender { return *p },
 		},
 	}
 }
@@ -1023,7 +1057,7 @@ type Group struct {
 }
 
 type groupBuilder struct {
-	builder[groupBuilder, *groupBuilder, Group]
+	builder[groupBuilder, *groupBuilder, Group, *Group]
 }
 
 func (b *groupBuilder) lazy(ds *Fetch, idI any) *Group {
@@ -1060,193 +1094,210 @@ func (b *groupBuilder) Preload(rel builderWrapperI) *groupBuilder {
 
 func (b *groupBuilder) AdminGroupForMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AdminGroupForMeetingID",
 			relField: "AdminGroupForMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) AnonymousGroupForMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AnonymousGroupForMeetingID",
 			relField: "AnonymousGroupForMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) DefaultGroupForMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultGroupForMeetingID",
 			relField: "DefaultGroupForMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) MeetingMediafileAccessGroupList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingMediafileAccessGroupIDs",
 			relField: "MeetingMediafileAccessGroupList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) MeetingMediafileInheritedAccessGroupList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingMediafileInheritedAccessGroupIDs",
 			relField: "MeetingMediafileInheritedAccessGroupList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) MeetingUserList() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserIDs",
 			relField: "MeetingUserList",
 			many:     true,
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) PollList() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollIDs",
 			relField: "PollList",
 			many:     true,
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) ReadChatGroupList() *chatGroupBuilder {
 	return &chatGroupBuilder{
-		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]{
+		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup, *ChatGroup]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReadChatGroupIDs",
 			relField: "ReadChatGroupList",
 			many:     true,
+			conv:     func(p *ChatGroup) ChatGroup { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) ReadCommentSectionList() *motionCommentSectionBuilder {
 	return &motionCommentSectionBuilder{
-		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]{
+		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection, *MotionCommentSection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReadCommentSectionIDs",
 			relField: "ReadCommentSectionList",
 			many:     true,
+			conv:     func(p *MotionCommentSection) MotionCommentSection { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) UsedAsAssignmentPollDefault() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsAssignmentPollDefaultID",
 			relField: "UsedAsAssignmentPollDefault",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) UsedAsMotionPollDefault() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsMotionPollDefaultID",
 			relField: "UsedAsMotionPollDefault",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) UsedAsPollDefault() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsPollDefaultID",
 			relField: "UsedAsPollDefault",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) UsedAsTopicPollDefault() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsTopicPollDefaultID",
 			relField: "UsedAsTopicPollDefault",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) WriteChatGroupList() *chatGroupBuilder {
 	return &chatGroupBuilder{
-		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]{
+		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup, *ChatGroup]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "WriteChatGroupIDs",
 			relField: "WriteChatGroupList",
 			many:     true,
+			conv:     func(p *ChatGroup) ChatGroup { return *p },
 		},
 	}
 }
 
 func (b *groupBuilder) WriteCommentSectionList() *motionCommentSectionBuilder {
 	return &motionCommentSectionBuilder{
-		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]{
+		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection, *MotionCommentSection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "WriteCommentSectionIDs",
 			relField: "WriteCommentSectionList",
 			many:     true,
+			conv:     func(p *MotionCommentSection) MotionCommentSection { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Group(ids ...int) *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Group) Group { return *p },
 		},
 	}
 }
@@ -1260,12 +1311,12 @@ type HistoryEntry struct {
 	OriginalModelID string
 	PositionID      int
 	Meeting         *dsfetch.Maybe[Meeting]
-	Model           *dsfetch.Maybe[HistoryEntryModelUnion]
+	Model           HistoryEntryModelUnion
 	Position        *HistoryPosition
 }
 
 type historyEntryBuilder struct {
-	builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]
+	builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]
 }
 
 func (b *historyEntryBuilder) lazy(ds *Fetch, idI any) *HistoryEntry {
@@ -1287,22 +1338,24 @@ func (b *historyEntryBuilder) Preload(rel builderWrapperI) *historyEntryBuilder 
 
 func (b *historyEntryBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *historyEntryBuilder) Model() *historyEntryModelUnionBuilder {
 	return &historyEntryModelUnionBuilder{
-		builder: builder[historyEntryModelUnionBuilder, *historyEntryModelUnionBuilder, HistoryEntryModelUnion]{
+		builder: builder[historyEntryModelUnionBuilder, *historyEntryModelUnionBuilder, HistoryEntryModelUnion, HistoryEntryModelUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ModelID",
 			relField: "Model",
+			conv:     func(u HistoryEntryModelUnion) HistoryEntryModelUnion { return u },
 		},
 	}
 }
@@ -1316,10 +1369,10 @@ func (*Motion) isHistoryEntryModelUnion()     {}
 func (*Assignment) isHistoryEntryModelUnion() {}
 
 type historyEntryModelUnionBuilder struct {
-	builder[historyEntryModelUnionBuilder, *historyEntryModelUnionBuilder, HistoryEntryModelUnion]
+	builder[historyEntryModelUnionBuilder, *historyEntryModelUnionBuilder, HistoryEntryModelUnion, HistoryEntryModelUnion]
 }
 
-func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryModelUnion {
+func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) HistoryEntryModelUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -1335,42 +1388,31 @@ func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryMod
 		return nil
 	}
 
-	var iface HistoryEntryModelUnion
 	switch collection {
-
 	case "user":
-
 		builder := &userBuilder{
-			builder: builder[userBuilder, *userBuilder, User]{
+			builder: builder[userBuilder, *userBuilder, User, *User]{
 				fetch: ds,
+				conv:  func(p *User) User { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "motion":
-
 		builder := &motionBuilder{
-			builder: builder[motionBuilder, *motionBuilder, Motion]{
+			builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 				fetch: ds,
+				conv:  func(p *Motion) Motion { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "assignment":
-
 		builder := &assignmentBuilder{
-			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 				fetch: ds,
+				conv:  func(p *Assignment) Assignment { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -1383,20 +1425,22 @@ func (b *historyEntryModelUnionBuilder) Preload(rel builderWrapperI) *historyEnt
 
 func (b *historyEntryBuilder) Position() *historyPositionBuilder {
 	return &historyPositionBuilder{
-		builder: builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition]{
+		builder: builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition, *HistoryPosition]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PositionID",
 			relField: "Position",
+			conv:     func(p *HistoryPosition) HistoryPosition { return *p },
 		},
 	}
 }
 
 func (r *Fetch) HistoryEntry(ids ...int) *historyEntryBuilder {
 	return &historyEntryBuilder{
-		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]{
+		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *HistoryEntry) HistoryEntry { return *p },
 		},
 	}
 }
@@ -1413,7 +1457,7 @@ type HistoryPosition struct {
 }
 
 type historyPositionBuilder struct {
-	builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition]
+	builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition, *HistoryPosition]
 }
 
 func (b *historyPositionBuilder) lazy(ds *Fetch, idI any) *HistoryPosition {
@@ -1434,32 +1478,35 @@ func (b *historyPositionBuilder) Preload(rel builderWrapperI) *historyPositionBu
 
 func (b *historyPositionBuilder) EntryList() *historyEntryBuilder {
 	return &historyEntryBuilder{
-		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]{
+		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "EntryIDs",
 			relField: "EntryList",
 			many:     true,
+			conv:     func(p *HistoryEntry) HistoryEntry { return *p },
 		},
 	}
 }
 
 func (b *historyPositionBuilder) User() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UserID",
 			relField: "User",
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (r *Fetch) HistoryPosition(ids ...int) *historyPositionBuilder {
 	return &historyPositionBuilder{
-		builder: builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition]{
+		builder: builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition, *HistoryPosition]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *HistoryPosition) HistoryPosition { return *p },
 		},
 	}
 }
@@ -1474,7 +1521,7 @@ type ImportPreview struct {
 }
 
 type importPreviewBuilder struct {
-	builder[importPreviewBuilder, *importPreviewBuilder, ImportPreview]
+	builder[importPreviewBuilder, *importPreviewBuilder, ImportPreview, *ImportPreview]
 }
 
 func (b *importPreviewBuilder) lazy(ds *Fetch, idI any) *ImportPreview {
@@ -1495,9 +1542,10 @@ func (b *importPreviewBuilder) Preload(rel builderWrapperI) *importPreviewBuilde
 
 func (r *Fetch) ImportPreview(ids ...int) *importPreviewBuilder {
 	return &importPreviewBuilder{
-		builder: builder[importPreviewBuilder, *importPreviewBuilder, ImportPreview]{
+		builder: builder[importPreviewBuilder, *importPreviewBuilder, ImportPreview, *ImportPreview]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ImportPreview) ImportPreview { return *p },
 		},
 	}
 }
@@ -1513,7 +1561,7 @@ type ListOfSpeakers struct {
 	SequentialNumber                 int
 	SpeakerIDs                       []int
 	StructureLevelListOfSpeakersIDs  []int
-	ContentObject                    *ListOfSpeakersContentObjectUnion
+	ContentObject                    ListOfSpeakersContentObjectUnion
 	Meeting                          *Meeting
 	ProjectionList                   []Projection
 	SpeakerList                      []Speaker
@@ -1521,7 +1569,7 @@ type ListOfSpeakers struct {
 }
 
 type listOfSpeakersBuilder struct {
-	builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]
+	builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]
 }
 
 func (b *listOfSpeakersBuilder) lazy(ds *Fetch, idI any) *ListOfSpeakers {
@@ -1546,11 +1594,12 @@ func (b *listOfSpeakersBuilder) Preload(rel builderWrapperI) *listOfSpeakersBuil
 
 func (b *listOfSpeakersBuilder) ContentObject() *listOfSpeakersContentObjectUnionBuilder {
 	return &listOfSpeakersContentObjectUnionBuilder{
-		builder: builder[listOfSpeakersContentObjectUnionBuilder, *listOfSpeakersContentObjectUnionBuilder, ListOfSpeakersContentObjectUnion]{
+		builder: builder[listOfSpeakersContentObjectUnionBuilder, *listOfSpeakersContentObjectUnionBuilder, ListOfSpeakersContentObjectUnion, ListOfSpeakersContentObjectUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ContentObjectID",
 			relField: "ContentObject",
+			conv:     func(u ListOfSpeakersContentObjectUnion) ListOfSpeakersContentObjectUnion { return u },
 		},
 	}
 }
@@ -1566,10 +1615,10 @@ func (*Topic) isListOfSpeakersContentObjectUnion()            {}
 func (*MeetingMediafile) isListOfSpeakersContentObjectUnion() {}
 
 type listOfSpeakersContentObjectUnionBuilder struct {
-	builder[listOfSpeakersContentObjectUnionBuilder, *listOfSpeakersContentObjectUnionBuilder, ListOfSpeakersContentObjectUnion]
+	builder[listOfSpeakersContentObjectUnionBuilder, *listOfSpeakersContentObjectUnionBuilder, ListOfSpeakersContentObjectUnion, ListOfSpeakersContentObjectUnion]
 }
 
-func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListOfSpeakersContentObjectUnion {
+func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) ListOfSpeakersContentObjectUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -1585,64 +1634,47 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 		return nil
 	}
 
-	var iface ListOfSpeakersContentObjectUnion
 	switch collection {
-
 	case "motion":
-
 		builder := &motionBuilder{
-			builder: builder[motionBuilder, *motionBuilder, Motion]{
+			builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 				fetch: ds,
+				conv:  func(p *Motion) Motion { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "motion_block":
-
 		builder := &motionBlockBuilder{
-			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]{
 				fetch: ds,
+				conv:  func(p *MotionBlock) MotionBlock { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "assignment":
-
 		builder := &assignmentBuilder{
-			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 				fetch: ds,
+				conv:  func(p *Assignment) Assignment { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "topic":
-
 		builder := &topicBuilder{
-			builder: builder[topicBuilder, *topicBuilder, Topic]{
+			builder: builder[topicBuilder, *topicBuilder, Topic, *Topic]{
 				fetch: ds,
+				conv:  func(p *Topic) Topic { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "meeting_mediafile":
-
 		builder := &meetingMediafileBuilder{
-			builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+			builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 				fetch: ds,
+				conv:  func(p *MeetingMediafile) MeetingMediafile { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -1655,56 +1687,61 @@ func (b *listOfSpeakersContentObjectUnionBuilder) Preload(rel builderWrapperI) *
 
 func (b *listOfSpeakersBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *listOfSpeakersBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *listOfSpeakersBuilder) SpeakerList() *speakerBuilder {
 	return &speakerBuilder{
-		builder: builder[speakerBuilder, *speakerBuilder, Speaker]{
+		builder: builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SpeakerIDs",
 			relField: "SpeakerList",
 			many:     true,
+			conv:     func(p *Speaker) Speaker { return *p },
 		},
 	}
 }
 
 func (b *listOfSpeakersBuilder) StructureLevelListOfSpeakersList() *structureLevelListOfSpeakersBuilder {
 	return &structureLevelListOfSpeakersBuilder{
-		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]{
+		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers, *StructureLevelListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelListOfSpeakersIDs",
 			relField: "StructureLevelListOfSpeakersList",
 			many:     true,
+			conv:     func(p *StructureLevelListOfSpeakers) StructureLevelListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (r *Fetch) ListOfSpeakers(ids ...int) *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
@@ -1727,13 +1764,13 @@ type Mediafile struct {
 	Token                               string
 	ChildList                           []Mediafile
 	MeetingMediafileList                []MeetingMediafile
-	Owner                               *MediafileOwnerUnion
+	Owner                               MediafileOwnerUnion
 	Parent                              *dsfetch.Maybe[Mediafile]
 	PublishedToMeetingsInOrganization   *dsfetch.Maybe[Organization]
 }
 
 type mediafileBuilder struct {
-	builder[mediafileBuilder, *mediafileBuilder, Mediafile]
+	builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]
 }
 
 func (b *mediafileBuilder) lazy(ds *Fetch, idI any) *Mediafile {
@@ -1763,35 +1800,38 @@ func (b *mediafileBuilder) Preload(rel builderWrapperI) *mediafileBuilder {
 
 func (b *mediafileBuilder) ChildList() *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChildIDs",
 			relField: "ChildList",
 			many:     true,
+			conv:     func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
 
 func (b *mediafileBuilder) MeetingMediafileList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingMediafileIDs",
 			relField: "MeetingMediafileList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *mediafileBuilder) Owner() *mediafileOwnerUnionBuilder {
 	return &mediafileOwnerUnionBuilder{
-		builder: builder[mediafileOwnerUnionBuilder, *mediafileOwnerUnionBuilder, MediafileOwnerUnion]{
+		builder: builder[mediafileOwnerUnionBuilder, *mediafileOwnerUnionBuilder, MediafileOwnerUnion, MediafileOwnerUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OwnerID",
 			relField: "Owner",
+			conv:     func(u MediafileOwnerUnion) MediafileOwnerUnion { return u },
 		},
 	}
 }
@@ -1804,10 +1844,10 @@ func (*Meeting) isMediafileOwnerUnion()      {}
 func (*Organization) isMediafileOwnerUnion() {}
 
 type mediafileOwnerUnionBuilder struct {
-	builder[mediafileOwnerUnionBuilder, *mediafileOwnerUnionBuilder, MediafileOwnerUnion]
+	builder[mediafileOwnerUnionBuilder, *mediafileOwnerUnionBuilder, MediafileOwnerUnion, MediafileOwnerUnion]
 }
 
-func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) *MediafileOwnerUnion {
+func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) MediafileOwnerUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -1823,31 +1863,23 @@ func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) *MediafileOwnerUnio
 		return nil
 	}
 
-	var iface MediafileOwnerUnion
 	switch collection {
-
 	case "meeting":
-
 		builder := &meetingBuilder{
-			builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+			builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 				fetch: ds,
+				conv:  func(p *Meeting) Meeting { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "organization":
-
 		builder := &organizationBuilder{
-			builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+			builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 				fetch: ds,
+				conv:  func(p *Organization) Organization { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -1860,31 +1892,34 @@ func (b *mediafileOwnerUnionBuilder) Preload(rel builderWrapperI) *mediafileOwne
 
 func (b *mediafileBuilder) Parent() *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ParentID",
 			relField: "Parent",
+			conv:     func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
 
 func (b *mediafileBuilder) PublishedToMeetingsInOrganization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PublishedToMeetingsInOrganizationID",
 			relField: "PublishedToMeetingsInOrganization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Mediafile(ids ...int) *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
@@ -2221,7 +2256,7 @@ type Meeting struct {
 }
 
 type meetingBuilder struct {
-	builder[meetingBuilder, *meetingBuilder, Meeting]
+	builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]
 }
 
 func (b *meetingBuilder) lazy(ds *Fetch, idI any) *Meeting {
@@ -2477,1024 +2512,1112 @@ func (b *meetingBuilder) Preload(rel builderWrapperI) *meetingBuilder {
 
 func (b *meetingBuilder) AdminGroup() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AdminGroupID",
 			relField: "AdminGroup",
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) AgendaItemList() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AgendaItemIDs",
 			relField: "AgendaItemList",
 			many:     true,
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) AllProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AllProjectionIDs",
 			relField: "AllProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) AnonymousGroup() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AnonymousGroupID",
 			relField: "AnonymousGroup",
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) AssignmentCandidateList() *assignmentCandidateBuilder {
 	return &assignmentCandidateBuilder{
-		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate]{
+		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate, *AssignmentCandidate]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AssignmentCandidateIDs",
 			relField: "AssignmentCandidateList",
 			many:     true,
+			conv:     func(p *AssignmentCandidate) AssignmentCandidate { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) AssignmentList() *assignmentBuilder {
 	return &assignmentBuilder{
-		builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+		builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AssignmentIDs",
 			relField: "AssignmentList",
 			many:     true,
+			conv:     func(p *Assignment) Assignment { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) AssignmentPollDefaultGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AssignmentPollDefaultGroupIDs",
 			relField: "AssignmentPollDefaultGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ChatGroupList() *chatGroupBuilder {
 	return &chatGroupBuilder{
-		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]{
+		builder: builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup, *ChatGroup]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChatGroupIDs",
 			relField: "ChatGroupList",
 			many:     true,
+			conv:     func(p *ChatGroup) ChatGroup { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ChatMessageList() *chatMessageBuilder {
 	return &chatMessageBuilder{
-		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage]{
+		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage, *ChatMessage]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChatMessageIDs",
 			relField: "ChatMessageList",
 			many:     true,
+			conv:     func(p *ChatMessage) ChatMessage { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) Committee() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CommitteeID",
 			relField: "Committee",
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultGroup() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultGroupID",
 			relField: "DefaultGroup",
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultMeetingForCommittee() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultMeetingForCommitteeID",
 			relField: "DefaultMeetingForCommittee",
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorAgendaItemListList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorAgendaItemListIDs",
 			relField: "DefaultProjectorAgendaItemListList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorAmendmentList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorAmendmentIDs",
 			relField: "DefaultProjectorAmendmentList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorAssignmentList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorAssignmentIDs",
 			relField: "DefaultProjectorAssignmentList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorAssignmentPollList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorAssignmentPollIDs",
 			relField: "DefaultProjectorAssignmentPollList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorCountdownList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorCountdownIDs",
 			relField: "DefaultProjectorCountdownList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorCurrentLosList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorCurrentLosIDs",
 			relField: "DefaultProjectorCurrentLosList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorListOfSpeakersList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorListOfSpeakersIDs",
 			relField: "DefaultProjectorListOfSpeakersList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorMediafileList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorMediafileIDs",
 			relField: "DefaultProjectorMediafileList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorMessageList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorMessageIDs",
 			relField: "DefaultProjectorMessageList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorMotionBlockList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorMotionBlockIDs",
 			relField: "DefaultProjectorMotionBlockList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorMotionList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorMotionIDs",
 			relField: "DefaultProjectorMotionList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorMotionPollList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorMotionPollIDs",
 			relField: "DefaultProjectorMotionPollList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorPollList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorPollIDs",
 			relField: "DefaultProjectorPollList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) DefaultProjectorTopicList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultProjectorTopicIDs",
 			relField: "DefaultProjectorTopicList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontBold() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontBoldID",
 			relField: "FontBold",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontBoldItalic() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontBoldItalicID",
 			relField: "FontBoldItalic",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontChyronSpeakerName() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontChyronSpeakerNameID",
 			relField: "FontChyronSpeakerName",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontItalic() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontItalicID",
 			relField: "FontItalic",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontMonospace() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontMonospaceID",
 			relField: "FontMonospace",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontProjectorH1() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontProjectorH1ID",
 			relField: "FontProjectorH1",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontProjectorH2() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontProjectorH2ID",
 			relField: "FontProjectorH2",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) FontRegular() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FontRegularID",
 			relField: "FontRegular",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ForwardedMotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ForwardedMotionIDs",
 			relField: "ForwardedMotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) GroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "GroupIDs",
 			relField: "GroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) IsActiveInOrganization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "IsActiveInOrganizationID",
 			relField: "IsActiveInOrganization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) IsArchivedInOrganization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "IsArchivedInOrganizationID",
 			relField: "IsArchivedInOrganization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ListOfSpeakersCountdown() *projectorCountdownBuilder {
 	return &projectorCountdownBuilder{
-		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]{
+		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown, *ProjectorCountdown]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersCountdownID",
 			relField: "ListOfSpeakersCountdown",
+			conv:     func(p *ProjectorCountdown) ProjectorCountdown { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ListOfSpeakersList() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersIDs",
 			relField: "ListOfSpeakersList",
 			many:     true,
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoPdfBallotPaper() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoPdfBallotPaperID",
 			relField: "LogoPdfBallotPaper",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoPdfFooterL() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoPdfFooterLID",
 			relField: "LogoPdfFooterL",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoPdfFooterR() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoPdfFooterRID",
 			relField: "LogoPdfFooterR",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoPdfHeaderL() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoPdfHeaderLID",
 			relField: "LogoPdfHeaderL",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoPdfHeaderR() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoPdfHeaderRID",
 			relField: "LogoPdfHeaderR",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoProjectorHeader() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoProjectorHeaderID",
 			relField: "LogoProjectorHeader",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoProjectorMain() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoProjectorMainID",
 			relField: "LogoProjectorMain",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) LogoWebHeader() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LogoWebHeaderID",
 			relField: "LogoWebHeader",
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MediafileList() *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MediafileIDs",
 			relField: "MediafileList",
 			many:     true,
+			conv:     func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MeetingMediafileList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingMediafileIDs",
 			relField: "MeetingMediafileList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MeetingUserList() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserIDs",
 			relField: "MeetingUserList",
 			many:     true,
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionBlockList() *motionBlockBuilder {
 	return &motionBlockBuilder{
-		builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+		builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionBlockIDs",
 			relField: "MotionBlockList",
 			many:     true,
+			conv:     func(p *MotionBlock) MotionBlock { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionCategoryList() *motionCategoryBuilder {
 	return &motionCategoryBuilder{
-		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]{
+		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory, *MotionCategory]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionCategoryIDs",
 			relField: "MotionCategoryList",
 			many:     true,
+			conv:     func(p *MotionCategory) MotionCategory { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionChangeRecommendationList() *motionChangeRecommendationBuilder {
 	return &motionChangeRecommendationBuilder{
-		builder: builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation]{
+		builder: builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation, *MotionChangeRecommendation]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionChangeRecommendationIDs",
 			relField: "MotionChangeRecommendationList",
 			many:     true,
+			conv:     func(p *MotionChangeRecommendation) MotionChangeRecommendation { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionCommentList() *motionCommentBuilder {
 	return &motionCommentBuilder{
-		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment]{
+		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment, *MotionComment]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionCommentIDs",
 			relField: "MotionCommentList",
 			many:     true,
+			conv:     func(p *MotionComment) MotionComment { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionCommentSectionList() *motionCommentSectionBuilder {
 	return &motionCommentSectionBuilder{
-		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]{
+		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection, *MotionCommentSection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionCommentSectionIDs",
 			relField: "MotionCommentSectionList",
 			many:     true,
+			conv:     func(p *MotionCommentSection) MotionCommentSection { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionEditorList() *motionEditorBuilder {
 	return &motionEditorBuilder{
-		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor]{
+		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor, *MotionEditor]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionEditorIDs",
 			relField: "MotionEditorList",
 			many:     true,
+			conv:     func(p *MotionEditor) MotionEditor { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionIDs",
 			relField: "MotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionPollDefaultGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionPollDefaultGroupIDs",
 			relField: "MotionPollDefaultGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionStateList() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionStateIDs",
 			relField: "MotionStateList",
 			many:     true,
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionSubmitterList() *motionSubmitterBuilder {
 	return &motionSubmitterBuilder{
-		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter]{
+		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter, *MotionSubmitter]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionSubmitterIDs",
 			relField: "MotionSubmitterList",
 			many:     true,
+			conv:     func(p *MotionSubmitter) MotionSubmitter { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionSupporterList() *motionSupporterBuilder {
 	return &motionSupporterBuilder{
-		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter]{
+		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter, *MotionSupporter]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionSupporterIDs",
 			relField: "MotionSupporterList",
 			many:     true,
+			conv:     func(p *MotionSupporter) MotionSupporter { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionWorkflowList() *motionWorkflowBuilder {
 	return &motionWorkflowBuilder{
-		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]{
+		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionWorkflowIDs",
 			relField: "MotionWorkflowList",
 			many:     true,
+			conv:     func(p *MotionWorkflow) MotionWorkflow { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionWorkingGroupSpeakerList() *motionWorkingGroupSpeakerBuilder {
 	return &motionWorkingGroupSpeakerBuilder{
-		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker]{
+		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker, *MotionWorkingGroupSpeaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionWorkingGroupSpeakerIDs",
 			relField: "MotionWorkingGroupSpeakerList",
 			many:     true,
+			conv:     func(p *MotionWorkingGroupSpeaker) MotionWorkingGroupSpeaker { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionsDefaultAmendmentWorkflow() *motionWorkflowBuilder {
 	return &motionWorkflowBuilder{
-		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]{
+		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionsDefaultAmendmentWorkflowID",
 			relField: "MotionsDefaultAmendmentWorkflow",
+			conv:     func(p *MotionWorkflow) MotionWorkflow { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) MotionsDefaultWorkflow() *motionWorkflowBuilder {
 	return &motionWorkflowBuilder{
-		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]{
+		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionsDefaultWorkflowID",
 			relField: "MotionsDefaultWorkflow",
+			conv:     func(p *MotionWorkflow) MotionWorkflow { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) OrganizationTagList() *organizationTagBuilder {
 	return &organizationTagBuilder{
-		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag]{
+		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag, *OrganizationTag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationTagIDs",
 			relField: "OrganizationTagList",
 			many:     true,
+			conv:     func(p *OrganizationTag) OrganizationTag { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) PersonalNoteList() *personalNoteBuilder {
 	return &personalNoteBuilder{
-		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote]{
+		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote, *PersonalNote]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PersonalNoteIDs",
 			relField: "PersonalNoteList",
 			many:     true,
+			conv:     func(p *PersonalNote) PersonalNote { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) PointOfOrderCategoryList() *pointOfOrderCategoryBuilder {
 	return &pointOfOrderCategoryBuilder{
-		builder: builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory]{
+		builder: builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory, *PointOfOrderCategory]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PointOfOrderCategoryIDs",
 			relField: "PointOfOrderCategoryList",
 			many:     true,
+			conv:     func(p *PointOfOrderCategory) PointOfOrderCategory { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) PollCountdown() *projectorCountdownBuilder {
 	return &projectorCountdownBuilder{
-		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]{
+		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown, *ProjectorCountdown]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollCountdownID",
 			relField: "PollCountdown",
+			conv:     func(p *ProjectorCountdown) ProjectorCountdown { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) PollDefaultGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollDefaultGroupIDs",
 			relField: "PollDefaultGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) PollList() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollIDs",
 			relField: "PollList",
 			many:     true,
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) PresentUserList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PresentUserIDs",
 			relField: "PresentUserList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ProjectorCountdownList() *projectorCountdownBuilder {
 	return &projectorCountdownBuilder{
-		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]{
+		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown, *ProjectorCountdown]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectorCountdownIDs",
 			relField: "ProjectorCountdownList",
 			many:     true,
+			conv:     func(p *ProjectorCountdown) ProjectorCountdown { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ProjectorList() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectorIDs",
 			relField: "ProjectorList",
 			many:     true,
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ProjectorMessageList() *projectorMessageBuilder {
 	return &projectorMessageBuilder{
-		builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage]{
+		builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage, *ProjectorMessage]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectorMessageIDs",
 			relField: "ProjectorMessageList",
 			many:     true,
+			conv:     func(p *ProjectorMessage) ProjectorMessage { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) ReferenceProjector() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReferenceProjectorID",
 			relField: "ReferenceProjector",
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) RelevantHistoryEntryList() *historyEntryBuilder {
 	return &historyEntryBuilder{
-		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]{
+		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "RelevantHistoryEntryIDs",
 			relField: "RelevantHistoryEntryList",
 			many:     true,
+			conv:     func(p *HistoryEntry) HistoryEntry { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) SpeakerList() *speakerBuilder {
 	return &speakerBuilder{
-		builder: builder[speakerBuilder, *speakerBuilder, Speaker]{
+		builder: builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SpeakerIDs",
 			relField: "SpeakerList",
 			many:     true,
+			conv:     func(p *Speaker) Speaker { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) StructureLevelList() *structureLevelBuilder {
 	return &structureLevelBuilder{
-		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel]{
+		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel, *StructureLevel]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelIDs",
 			relField: "StructureLevelList",
 			many:     true,
+			conv:     func(p *StructureLevel) StructureLevel { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) StructureLevelListOfSpeakersList() *structureLevelListOfSpeakersBuilder {
 	return &structureLevelListOfSpeakersBuilder{
-		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]{
+		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers, *StructureLevelListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelListOfSpeakersIDs",
 			relField: "StructureLevelListOfSpeakersList",
 			many:     true,
+			conv:     func(p *StructureLevelListOfSpeakers) StructureLevelListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) TagList() *tagBuilder {
 	return &tagBuilder{
-		builder: builder[tagBuilder, *tagBuilder, Tag]{
+		builder: builder[tagBuilder, *tagBuilder, Tag, *Tag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TagIDs",
 			relField: "TagList",
 			many:     true,
+			conv:     func(p *Tag) Tag { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) TemplateForOrganization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TemplateForOrganizationID",
 			relField: "TemplateForOrganization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) TopicList() *topicBuilder {
 	return &topicBuilder{
-		builder: builder[topicBuilder, *topicBuilder, Topic]{
+		builder: builder[topicBuilder, *topicBuilder, Topic, *Topic]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TopicIDs",
 			relField: "TopicList",
 			many:     true,
+			conv:     func(p *Topic) Topic { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) TopicPollDefaultGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TopicPollDefaultGroupIDs",
 			relField: "TopicPollDefaultGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingBuilder) UserList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UserIDs",
 			relField: "UserList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Meeting(ids ...int) *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
@@ -3551,7 +3674,7 @@ type MeetingMediafile struct {
 }
 
 type meetingMediafileBuilder struct {
-	builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]
+	builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]
 }
 
 func (b *meetingMediafileBuilder) lazy(ds *Fetch, idI any) *MeetingMediafile {
@@ -3592,254 +3715,277 @@ func (b *meetingMediafileBuilder) Preload(rel builderWrapperI) *meetingMediafile
 
 func (b *meetingMediafileBuilder) AccessGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AccessGroupIDs",
 			relField: "AccessGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) InheritedAccessGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "InheritedAccessGroupIDs",
 			relField: "InheritedAccessGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) Mediafile() *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MediafileID",
 			relField: "Mediafile",
+			conv:     func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontBoldInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontBoldInMeetingID",
 			relField: "UsedAsFontBoldInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontBoldItalicInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontBoldItalicInMeetingID",
 			relField: "UsedAsFontBoldItalicInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontChyronSpeakerNameInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontChyronSpeakerNameInMeetingID",
 			relField: "UsedAsFontChyronSpeakerNameInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontItalicInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontItalicInMeetingID",
 			relField: "UsedAsFontItalicInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontMonospaceInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontMonospaceInMeetingID",
 			relField: "UsedAsFontMonospaceInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontProjectorH1InMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontProjectorH1InMeetingID",
 			relField: "UsedAsFontProjectorH1InMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontProjectorH2InMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontProjectorH2InMeetingID",
 			relField: "UsedAsFontProjectorH2InMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsFontRegularInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsFontRegularInMeetingID",
 			relField: "UsedAsFontRegularInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoPdfBallotPaperInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoPdfBallotPaperInMeetingID",
 			relField: "UsedAsLogoPdfBallotPaperInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoPdfFooterLInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoPdfFooterLInMeetingID",
 			relField: "UsedAsLogoPdfFooterLInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoPdfFooterRInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoPdfFooterRInMeetingID",
 			relField: "UsedAsLogoPdfFooterRInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoPdfHeaderLInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoPdfHeaderLInMeetingID",
 			relField: "UsedAsLogoPdfHeaderLInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoPdfHeaderRInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoPdfHeaderRInMeetingID",
 			relField: "UsedAsLogoPdfHeaderRInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoProjectorHeaderInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoProjectorHeaderInMeetingID",
 			relField: "UsedAsLogoProjectorHeaderInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoProjectorMainInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoProjectorMainInMeetingID",
 			relField: "UsedAsLogoProjectorMainInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingMediafileBuilder) UsedAsLogoWebHeaderInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsLogoWebHeaderInMeetingID",
 			relField: "UsedAsLogoWebHeaderInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MeetingMediafile(ids ...int) *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
@@ -3891,7 +4037,7 @@ type MeetingUser struct {
 }
 
 type meetingUserBuilder struct {
-	builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]
+	builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]
 }
 
 func (b *meetingUserBuilder) lazy(ds *Fetch, idI any) *MeetingUser {
@@ -3931,222 +4077,241 @@ func (b *meetingUserBuilder) Preload(rel builderWrapperI) *meetingUserBuilder {
 
 func (b *meetingUserBuilder) ActingBallotList() *pollBallotBuilder {
 	return &pollBallotBuilder{
-		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot]{
+		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot, *PollBallot]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ActingBallotIDs",
 			relField: "ActingBallotList",
 			many:     true,
+			conv:     func(p *PollBallot) PollBallot { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) AssignmentCandidateList() *assignmentCandidateBuilder {
 	return &assignmentCandidateBuilder{
-		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate]{
+		builder: builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate, *AssignmentCandidate]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AssignmentCandidateIDs",
 			relField: "AssignmentCandidateList",
 			many:     true,
+			conv:     func(p *AssignmentCandidate) AssignmentCandidate { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) ChatMessageList() *chatMessageBuilder {
 	return &chatMessageBuilder{
-		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage]{
+		builder: builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage, *ChatMessage]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChatMessageIDs",
 			relField: "ChatMessageList",
 			many:     true,
+			conv:     func(p *ChatMessage) ChatMessage { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) GroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "GroupIDs",
 			relField: "GroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) MotionEditorList() *motionEditorBuilder {
 	return &motionEditorBuilder{
-		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor]{
+		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor, *MotionEditor]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionEditorIDs",
 			relField: "MotionEditorList",
 			many:     true,
+			conv:     func(p *MotionEditor) MotionEditor { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) MotionSubmitterList() *motionSubmitterBuilder {
 	return &motionSubmitterBuilder{
-		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter]{
+		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter, *MotionSubmitter]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionSubmitterIDs",
 			relField: "MotionSubmitterList",
 			many:     true,
+			conv:     func(p *MotionSubmitter) MotionSubmitter { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) MotionSupporterList() *motionSupporterBuilder {
 	return &motionSupporterBuilder{
-		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter]{
+		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter, *MotionSupporter]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionSupporterIDs",
 			relField: "MotionSupporterList",
 			many:     true,
+			conv:     func(p *MotionSupporter) MotionSupporter { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) MotionWorkingGroupSpeakerList() *motionWorkingGroupSpeakerBuilder {
 	return &motionWorkingGroupSpeakerBuilder{
-		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker]{
+		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker, *MotionWorkingGroupSpeaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionWorkingGroupSpeakerIDs",
 			relField: "MotionWorkingGroupSpeakerList",
 			many:     true,
+			conv:     func(p *MotionWorkingGroupSpeaker) MotionWorkingGroupSpeaker { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) PersonalNoteList() *personalNoteBuilder {
 	return &personalNoteBuilder{
-		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote]{
+		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote, *PersonalNote]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PersonalNoteIDs",
 			relField: "PersonalNoteList",
 			many:     true,
+			conv:     func(p *PersonalNote) PersonalNote { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) PollOptionList() *pollOptionBuilder {
 	return &pollOptionBuilder{
-		builder: builder[pollOptionBuilder, *pollOptionBuilder, PollOption]{
+		builder: builder[pollOptionBuilder, *pollOptionBuilder, PollOption, *PollOption]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollOptionIDs",
 			relField: "PollOptionList",
 			many:     true,
+			conv:     func(p *PollOption) PollOption { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) PollVotedList() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollVotedIDs",
 			relField: "PollVotedList",
 			many:     true,
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) RepresentedBallotList() *pollBallotBuilder {
 	return &pollBallotBuilder{
-		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot]{
+		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot, *PollBallot]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "RepresentedBallotIDs",
 			relField: "RepresentedBallotList",
 			many:     true,
+			conv:     func(p *PollBallot) PollBallot { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) SpeakerList() *speakerBuilder {
 	return &speakerBuilder{
-		builder: builder[speakerBuilder, *speakerBuilder, Speaker]{
+		builder: builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SpeakerIDs",
 			relField: "SpeakerList",
 			many:     true,
+			conv:     func(p *Speaker) Speaker { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) StructureLevelList() *structureLevelBuilder {
 	return &structureLevelBuilder{
-		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel]{
+		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel, *StructureLevel]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelIDs",
 			relField: "StructureLevelList",
 			many:     true,
+			conv:     func(p *StructureLevel) StructureLevel { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) User() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UserID",
 			relField: "User",
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) VoteDelegatedTo() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "VoteDelegatedToID",
 			relField: "VoteDelegatedTo",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *meetingUserBuilder) VoteDelegationsFromList() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "VoteDelegationsFromIDs",
 			relField: "VoteDelegationsFromList",
 			many:     true,
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MeetingUser(ids ...int) *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
@@ -4242,7 +4407,7 @@ type Motion struct {
 }
 
 type motionBuilder struct {
-	builder[motionBuilder, *motionBuilder, Motion]
+	builder[motionBuilder, *motionBuilder, Motion, *Motion]
 }
 
 func (b *motionBuilder) lazy(ds *Fetch, idI any) *Motion {
@@ -4313,370 +4478,402 @@ func (b *motionBuilder) Preload(rel builderWrapperI) *motionBuilder {
 
 func (b *motionBuilder) AgendaItem() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AgendaItemID",
 			relField: "AgendaItem",
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) AllDerivedMotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AllDerivedMotionIDs",
 			relField: "AllDerivedMotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) AllOriginList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AllOriginIDs",
 			relField: "AllOriginList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) AmendmentList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AmendmentIDs",
 			relField: "AmendmentList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) AttachmentMeetingMediafileList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AttachmentMeetingMediafileIDs",
 			relField: "AttachmentMeetingMediafileList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) Block() *motionBlockBuilder {
 	return &motionBlockBuilder{
-		builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+		builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "BlockID",
 			relField: "Block",
+			conv:     func(p *MotionBlock) MotionBlock { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) Category() *motionCategoryBuilder {
 	return &motionCategoryBuilder{
-		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]{
+		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory, *MotionCategory]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CategoryID",
 			relField: "Category",
+			conv:     func(p *MotionCategory) MotionCategory { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) ChangeRecommendationList() *motionChangeRecommendationBuilder {
 	return &motionChangeRecommendationBuilder{
-		builder: builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation]{
+		builder: builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation, *MotionChangeRecommendation]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChangeRecommendationIDs",
 			relField: "ChangeRecommendationList",
 			many:     true,
+			conv:     func(p *MotionChangeRecommendation) MotionChangeRecommendation { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) CommentList() *motionCommentBuilder {
 	return &motionCommentBuilder{
-		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment]{
+		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment, *MotionComment]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CommentIDs",
 			relField: "CommentList",
 			many:     true,
+			conv:     func(p *MotionComment) MotionComment { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) DerivedMotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DerivedMotionIDs",
 			relField: "DerivedMotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) EditorList() *motionEditorBuilder {
 	return &motionEditorBuilder{
-		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor]{
+		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor, *MotionEditor]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "EditorIDs",
 			relField: "EditorList",
 			many:     true,
+			conv:     func(p *MotionEditor) MotionEditor { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) HistoryEntryList() *historyEntryBuilder {
 	return &historyEntryBuilder{
-		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]{
+		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HistoryEntryIDs",
 			relField: "HistoryEntryList",
 			many:     true,
+			conv:     func(p *HistoryEntry) HistoryEntry { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) IDenticalMotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "IDenticalMotionIDs",
 			relField: "IDenticalMotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) LeadMotion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "LeadMotionID",
 			relField: "LeadMotion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) Origin() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OriginID",
 			relField: "Origin",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) OriginMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OriginMeetingID",
 			relField: "OriginMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) PersonalNoteList() *personalNoteBuilder {
 	return &personalNoteBuilder{
-		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote]{
+		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote, *PersonalNote]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PersonalNoteIDs",
 			relField: "PersonalNoteList",
 			many:     true,
+			conv:     func(p *PersonalNote) PersonalNote { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) PollList() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollIDs",
 			relField: "PollList",
 			many:     true,
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) Recommendation() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "RecommendationID",
 			relField: "Recommendation",
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) ReferencedInMotionRecommendationExtensionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReferencedInMotionRecommendationExtensionIDs",
 			relField: "ReferencedInMotionRecommendationExtensionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) ReferencedInMotionStateExtensionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReferencedInMotionStateExtensionIDs",
 			relField: "ReferencedInMotionStateExtensionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) SortChildList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SortChildIDs",
 			relField: "SortChildList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) SortParent() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SortParentID",
 			relField: "SortParent",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) State() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StateID",
 			relField: "State",
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) SubmitterList() *motionSubmitterBuilder {
 	return &motionSubmitterBuilder{
-		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter]{
+		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter, *MotionSubmitter]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SubmitterIDs",
 			relField: "SubmitterList",
 			many:     true,
+			conv:     func(p *MotionSubmitter) MotionSubmitter { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) SupporterList() *motionSupporterBuilder {
 	return &motionSupporterBuilder{
-		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter]{
+		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter, *MotionSupporter]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SupporterIDs",
 			relField: "SupporterList",
 			many:     true,
+			conv:     func(p *MotionSupporter) MotionSupporter { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) TagList() *tagBuilder {
 	return &tagBuilder{
-		builder: builder[tagBuilder, *tagBuilder, Tag]{
+		builder: builder[tagBuilder, *tagBuilder, Tag, *Tag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TagIDs",
 			relField: "TagList",
 			many:     true,
+			conv:     func(p *Tag) Tag { return *p },
 		},
 	}
 }
 
 func (b *motionBuilder) WorkingGroupSpeakerList() *motionWorkingGroupSpeakerBuilder {
 	return &motionWorkingGroupSpeakerBuilder{
-		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker]{
+		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker, *MotionWorkingGroupSpeaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "WorkingGroupSpeakerIDs",
 			relField: "WorkingGroupSpeakerList",
 			many:     true,
+			conv:     func(p *MotionWorkingGroupSpeaker) MotionWorkingGroupSpeaker { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Motion(ids ...int) *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Motion) Motion { return *p },
 		},
 	}
 }
@@ -4700,7 +4897,7 @@ type MotionBlock struct {
 }
 
 type motionBlockBuilder struct {
-	builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]
+	builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]
 }
 
 func (b *motionBlockBuilder) lazy(ds *Fetch, idI any) *MotionBlock {
@@ -4725,66 +4922,72 @@ func (b *motionBlockBuilder) Preload(rel builderWrapperI) *motionBlockBuilder {
 
 func (b *motionBlockBuilder) AgendaItem() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AgendaItemID",
 			relField: "AgendaItem",
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *motionBlockBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *motionBlockBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionBlockBuilder) MotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionIDs",
 			relField: "MotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionBlockBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionBlock(ids ...int) *motionBlockBuilder {
 	return &motionBlockBuilder{
-		builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+		builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionBlock) MotionBlock { return *p },
 		},
 	}
 }
@@ -4808,7 +5011,7 @@ type MotionCategory struct {
 }
 
 type motionCategoryBuilder struct {
-	builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]
+	builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory, *MotionCategory]
 }
 
 func (b *motionCategoryBuilder) lazy(ds *Fetch, idI any) *MotionCategory {
@@ -4834,55 +5037,60 @@ func (b *motionCategoryBuilder) Preload(rel builderWrapperI) *motionCategoryBuil
 
 func (b *motionCategoryBuilder) ChildList() *motionCategoryBuilder {
 	return &motionCategoryBuilder{
-		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]{
+		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory, *MotionCategory]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ChildIDs",
 			relField: "ChildList",
 			many:     true,
+			conv:     func(p *MotionCategory) MotionCategory { return *p },
 		},
 	}
 }
 
 func (b *motionCategoryBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionCategoryBuilder) MotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionIDs",
 			relField: "MotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionCategoryBuilder) Parent() *motionCategoryBuilder {
 	return &motionCategoryBuilder{
-		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]{
+		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory, *MotionCategory]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ParentID",
 			relField: "Parent",
+			conv:     func(p *MotionCategory) MotionCategory { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionCategory(ids ...int) *motionCategoryBuilder {
 	return &motionCategoryBuilder{
-		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]{
+		builder: builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory, *MotionCategory]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionCategory) MotionCategory { return *p },
 		},
 	}
 }
@@ -4905,7 +5113,7 @@ type MotionChangeRecommendation struct {
 }
 
 type motionChangeRecommendationBuilder struct {
-	builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation]
+	builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation, *MotionChangeRecommendation]
 }
 
 func (b *motionChangeRecommendationBuilder) lazy(ds *Fetch, idI any) *MotionChangeRecommendation {
@@ -4932,31 +5140,34 @@ func (b *motionChangeRecommendationBuilder) Preload(rel builderWrapperI) *motion
 
 func (b *motionChangeRecommendationBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionChangeRecommendationBuilder) Motion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionID",
 			relField: "Motion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionChangeRecommendation(ids ...int) *motionChangeRecommendationBuilder {
 	return &motionChangeRecommendationBuilder{
-		builder: builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation]{
+		builder: builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation, *MotionChangeRecommendation]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionChangeRecommendation) MotionChangeRecommendation { return *p },
 		},
 	}
 }
@@ -4974,7 +5185,7 @@ type MotionComment struct {
 }
 
 type motionCommentBuilder struct {
-	builder[motionCommentBuilder, *motionCommentBuilder, MotionComment]
+	builder[motionCommentBuilder, *motionCommentBuilder, MotionComment, *MotionComment]
 }
 
 func (b *motionCommentBuilder) lazy(ds *Fetch, idI any) *MotionComment {
@@ -4995,42 +5206,46 @@ func (b *motionCommentBuilder) Preload(rel builderWrapperI) *motionCommentBuilde
 
 func (b *motionCommentBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionCommentBuilder) Motion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionID",
 			relField: "Motion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionCommentBuilder) Section() *motionCommentSectionBuilder {
 	return &motionCommentSectionBuilder{
-		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]{
+		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection, *MotionCommentSection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SectionID",
 			relField: "Section",
+			conv:     func(p *MotionCommentSection) MotionCommentSection { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionComment(ids ...int) *motionCommentBuilder {
 	return &motionCommentBuilder{
-		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment]{
+		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment, *MotionComment]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionComment) MotionComment { return *p },
 		},
 	}
 }
@@ -5053,7 +5268,7 @@ type MotionCommentSection struct {
 }
 
 type motionCommentSectionBuilder struct {
-	builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]
+	builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection, *MotionCommentSection]
 }
 
 func (b *motionCommentSectionBuilder) lazy(ds *Fetch, idI any) *MotionCommentSection {
@@ -5078,56 +5293,61 @@ func (b *motionCommentSectionBuilder) Preload(rel builderWrapperI) *motionCommen
 
 func (b *motionCommentSectionBuilder) CommentList() *motionCommentBuilder {
 	return &motionCommentBuilder{
-		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment]{
+		builder: builder[motionCommentBuilder, *motionCommentBuilder, MotionComment, *MotionComment]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CommentIDs",
 			relField: "CommentList",
 			many:     true,
+			conv:     func(p *MotionComment) MotionComment { return *p },
 		},
 	}
 }
 
 func (b *motionCommentSectionBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionCommentSectionBuilder) ReadGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ReadGroupIDs",
 			relField: "ReadGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *motionCommentSectionBuilder) WriteGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "WriteGroupIDs",
 			relField: "WriteGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionCommentSection(ids ...int) *motionCommentSectionBuilder {
 	return &motionCommentSectionBuilder{
-		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]{
+		builder: builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection, *MotionCommentSection]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionCommentSection) MotionCommentSection { return *p },
 		},
 	}
 }
@@ -5145,7 +5365,7 @@ type MotionEditor struct {
 }
 
 type motionEditorBuilder struct {
-	builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor]
+	builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor, *MotionEditor]
 }
 
 func (b *motionEditorBuilder) lazy(ds *Fetch, idI any) *MotionEditor {
@@ -5166,42 +5386,46 @@ func (b *motionEditorBuilder) Preload(rel builderWrapperI) *motionEditorBuilder 
 
 func (b *motionEditorBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionEditorBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *motionEditorBuilder) Motion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionID",
 			relField: "Motion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionEditor(ids ...int) *motionEditorBuilder {
 	return &motionEditorBuilder{
-		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor]{
+		builder: builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor, *MotionEditor]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionEditor) MotionEditor { return *p },
 		},
 	}
 }
@@ -5247,7 +5471,7 @@ type MotionState struct {
 }
 
 type motionStateBuilder struct {
-	builder[motionStateBuilder, *motionStateBuilder, MotionState]
+	builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]
 }
 
 func (b *motionStateBuilder) lazy(ds *Fetch, idI any) *MotionState {
@@ -5290,113 +5514,123 @@ func (b *motionStateBuilder) Preload(rel builderWrapperI) *motionStateBuilder {
 
 func (b *motionStateBuilder) FirstStateOfWorkflow() *motionWorkflowBuilder {
 	return &motionWorkflowBuilder{
-		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]{
+		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FirstStateOfWorkflowID",
 			relField: "FirstStateOfWorkflow",
+			conv:     func(p *MotionWorkflow) MotionWorkflow { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) MotionList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionIDs",
 			relField: "MotionList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) MotionRecommendationList() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionRecommendationIDs",
 			relField: "MotionRecommendationList",
 			many:     true,
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) NextStateList() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "NextStateIDs",
 			relField: "NextStateList",
 			many:     true,
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) PreviousStateList() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PreviousStateIDs",
 			relField: "PreviousStateList",
 			many:     true,
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) SubmitterWithdrawBackList() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SubmitterWithdrawBackIDs",
 			relField: "SubmitterWithdrawBackList",
 			many:     true,
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) SubmitterWithdrawState() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SubmitterWithdrawStateID",
 			relField: "SubmitterWithdrawState",
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionStateBuilder) Workflow() *motionWorkflowBuilder {
 	return &motionWorkflowBuilder{
-		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]{
+		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "WorkflowID",
 			relField: "Workflow",
+			conv:     func(p *MotionWorkflow) MotionWorkflow { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionState(ids ...int) *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
@@ -5414,7 +5648,7 @@ type MotionSubmitter struct {
 }
 
 type motionSubmitterBuilder struct {
-	builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter]
+	builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter, *MotionSubmitter]
 }
 
 func (b *motionSubmitterBuilder) lazy(ds *Fetch, idI any) *MotionSubmitter {
@@ -5435,42 +5669,46 @@ func (b *motionSubmitterBuilder) Preload(rel builderWrapperI) *motionSubmitterBu
 
 func (b *motionSubmitterBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionSubmitterBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *motionSubmitterBuilder) Motion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionID",
 			relField: "Motion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionSubmitter(ids ...int) *motionSubmitterBuilder {
 	return &motionSubmitterBuilder{
-		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter]{
+		builder: builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter, *MotionSubmitter]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionSubmitter) MotionSubmitter { return *p },
 		},
 	}
 }
@@ -5487,7 +5725,7 @@ type MotionSupporter struct {
 }
 
 type motionSupporterBuilder struct {
-	builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter]
+	builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter, *MotionSupporter]
 }
 
 func (b *motionSupporterBuilder) lazy(ds *Fetch, idI any) *MotionSupporter {
@@ -5507,42 +5745,46 @@ func (b *motionSupporterBuilder) Preload(rel builderWrapperI) *motionSupporterBu
 
 func (b *motionSupporterBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionSupporterBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *motionSupporterBuilder) Motion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionID",
 			relField: "Motion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionSupporter(ids ...int) *motionSupporterBuilder {
 	return &motionSupporterBuilder{
-		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter]{
+		builder: builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter, *MotionSupporter]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionSupporter) MotionSupporter { return *p },
 		},
 	}
 }
@@ -5565,7 +5807,7 @@ type MotionWorkflow struct {
 }
 
 type motionWorkflowBuilder struct {
-	builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]
+	builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]
 }
 
 func (b *motionWorkflowBuilder) lazy(ds *Fetch, idI any) *MotionWorkflow {
@@ -5589,65 +5831,71 @@ func (b *motionWorkflowBuilder) Preload(rel builderWrapperI) *motionWorkflowBuil
 
 func (b *motionWorkflowBuilder) DefaultAmendmentWorkflowMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultAmendmentWorkflowMeetingID",
 			relField: "DefaultAmendmentWorkflowMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionWorkflowBuilder) DefaultWorkflowMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "DefaultWorkflowMeetingID",
 			relField: "DefaultWorkflowMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionWorkflowBuilder) FirstState() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "FirstStateID",
 			relField: "FirstState",
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (b *motionWorkflowBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionWorkflowBuilder) StateList() *motionStateBuilder {
 	return &motionStateBuilder{
-		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState]{
+		builder: builder[motionStateBuilder, *motionStateBuilder, MotionState, *MotionState]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StateIDs",
 			relField: "StateList",
 			many:     true,
+			conv:     func(p *MotionState) MotionState { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionWorkflow(ids ...int) *motionWorkflowBuilder {
 	return &motionWorkflowBuilder{
-		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]{
+		builder: builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow, *MotionWorkflow]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionWorkflow) MotionWorkflow { return *p },
 		},
 	}
 }
@@ -5665,7 +5913,7 @@ type MotionWorkingGroupSpeaker struct {
 }
 
 type motionWorkingGroupSpeakerBuilder struct {
-	builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker]
+	builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker, *MotionWorkingGroupSpeaker]
 }
 
 func (b *motionWorkingGroupSpeakerBuilder) lazy(ds *Fetch, idI any) *MotionWorkingGroupSpeaker {
@@ -5686,42 +5934,46 @@ func (b *motionWorkingGroupSpeakerBuilder) Preload(rel builderWrapperI) *motionW
 
 func (b *motionWorkingGroupSpeakerBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *motionWorkingGroupSpeakerBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *motionWorkingGroupSpeakerBuilder) Motion() *motionBuilder {
 	return &motionBuilder{
-		builder: builder[motionBuilder, *motionBuilder, Motion]{
+		builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MotionID",
 			relField: "Motion",
+			conv:     func(p *Motion) Motion { return *p },
 		},
 	}
 }
 
 func (r *Fetch) MotionWorkingGroupSpeaker(ids ...int) *motionWorkingGroupSpeakerBuilder {
 	return &motionWorkingGroupSpeakerBuilder{
-		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker]{
+		builder: builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker, *MotionWorkingGroupSpeaker]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *MotionWorkingGroupSpeaker) MotionWorkingGroupSpeaker { return *p },
 		},
 	}
 }
@@ -5782,7 +6034,7 @@ type Organization struct {
 }
 
 type organizationBuilder struct {
-	builder[organizationBuilder, *organizationBuilder, Organization]
+	builder[organizationBuilder, *organizationBuilder, Organization, *Organization]
 }
 
 func (b *organizationBuilder) lazy(ds *Fetch, idI any) *Organization {
@@ -5838,140 +6090,152 @@ func (b *organizationBuilder) Preload(rel builderWrapperI) *organizationBuilder 
 
 func (b *organizationBuilder) ActiveMeetingList() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ActiveMeetingIDs",
 			relField: "ActiveMeetingList",
 			many:     true,
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) ArchivedMeetingList() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ArchivedMeetingIDs",
 			relField: "ArchivedMeetingList",
 			many:     true,
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) CommitteeList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CommitteeIDs",
 			relField: "CommitteeList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) GenderList() *genderBuilder {
 	return &genderBuilder{
-		builder: builder[genderBuilder, *genderBuilder, Gender]{
+		builder: builder[genderBuilder, *genderBuilder, Gender, *Gender]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "GenderIDs",
 			relField: "GenderList",
 			many:     true,
+			conv:     func(p *Gender) Gender { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) MediafileList() *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MediafileIDs",
 			relField: "MediafileList",
 			many:     true,
+			conv:     func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) OrganizationTagList() *organizationTagBuilder {
 	return &organizationTagBuilder{
-		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag]{
+		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag, *OrganizationTag]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationTagIDs",
 			relField: "OrganizationTagList",
 			many:     true,
+			conv:     func(p *OrganizationTag) OrganizationTag { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) PublishedMediafileList() *mediafileBuilder {
 	return &mediafileBuilder{
-		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile]{
+		builder: builder[mediafileBuilder, *mediafileBuilder, Mediafile, *Mediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PublishedMediafileIDs",
 			relField: "PublishedMediafileList",
 			many:     true,
+			conv:     func(p *Mediafile) Mediafile { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) TemplateMeetingList() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "TemplateMeetingIDs",
 			relField: "TemplateMeetingList",
 			many:     true,
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) Theme() *themeBuilder {
 	return &themeBuilder{
-		builder: builder[themeBuilder, *themeBuilder, Theme]{
+		builder: builder[themeBuilder, *themeBuilder, Theme, *Theme]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ThemeID",
 			relField: "Theme",
+			conv:     func(p *Theme) Theme { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) ThemeList() *themeBuilder {
 	return &themeBuilder{
-		builder: builder[themeBuilder, *themeBuilder, Theme]{
+		builder: builder[themeBuilder, *themeBuilder, Theme, *Theme]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ThemeIDs",
 			relField: "ThemeList",
 			many:     true,
+			conv:     func(p *Theme) Theme { return *p },
 		},
 	}
 }
 
 func (b *organizationBuilder) UserList() *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UserIDs",
 			relField: "UserList",
 			many:     true,
+			conv:     func(p *User) User { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Organization(ids ...int) *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Organization) Organization { return *p },
 		},
 	}
 }
@@ -5987,7 +6251,7 @@ type OrganizationTag struct {
 }
 
 type organizationTagBuilder struct {
-	builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag]
+	builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag, *OrganizationTag]
 }
 
 func (b *organizationTagBuilder) lazy(ds *Fetch, idI any) *OrganizationTag {
@@ -6008,20 +6272,22 @@ func (b *organizationTagBuilder) Preload(rel builderWrapperI) *organizationTagBu
 
 func (b *organizationTagBuilder) Organization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationID",
 			relField: "Organization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (r *Fetch) OrganizationTag(ids ...int) *organizationTagBuilder {
 	return &organizationTagBuilder{
-		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag]{
+		builder: builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag, *OrganizationTag]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *OrganizationTag) OrganizationTag { return *p },
 		},
 	}
 }
@@ -6034,13 +6300,13 @@ type PersonalNote struct {
 	MeetingUserID   int
 	Note            string
 	Star            bool
-	ContentObject   *PersonalNoteContentObjectUnion
+	ContentObject   PersonalNoteContentObjectUnion
 	Meeting         *Meeting
 	MeetingUser     *MeetingUser
 }
 
 type personalNoteBuilder struct {
-	builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote]
+	builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote, *PersonalNote]
 }
 
 func (b *personalNoteBuilder) lazy(ds *Fetch, idI any) *PersonalNote {
@@ -6062,11 +6328,12 @@ func (b *personalNoteBuilder) Preload(rel builderWrapperI) *personalNoteBuilder 
 
 func (b *personalNoteBuilder) ContentObject() *personalNoteContentObjectUnionBuilder {
 	return &personalNoteContentObjectUnionBuilder{
-		builder: builder[personalNoteContentObjectUnionBuilder, *personalNoteContentObjectUnionBuilder, PersonalNoteContentObjectUnion]{
+		builder: builder[personalNoteContentObjectUnionBuilder, *personalNoteContentObjectUnionBuilder, PersonalNoteContentObjectUnion, PersonalNoteContentObjectUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ContentObjectID",
 			relField: "ContentObject",
+			conv:     func(u PersonalNoteContentObjectUnion) PersonalNoteContentObjectUnion { return u },
 		},
 	}
 }
@@ -6078,10 +6345,10 @@ type PersonalNoteContentObjectUnion interface {
 func (*Motion) isPersonalNoteContentObjectUnion() {}
 
 type personalNoteContentObjectUnionBuilder struct {
-	builder[personalNoteContentObjectUnionBuilder, *personalNoteContentObjectUnionBuilder, PersonalNoteContentObjectUnion]
+	builder[personalNoteContentObjectUnionBuilder, *personalNoteContentObjectUnionBuilder, PersonalNoteContentObjectUnion, PersonalNoteContentObjectUnion]
 }
 
-func (b *personalNoteContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PersonalNoteContentObjectUnion {
+func (b *personalNoteContentObjectUnionBuilder) lazy(ds *Fetch, id any) PersonalNoteContentObjectUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -6097,20 +6364,15 @@ func (b *personalNoteContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Persona
 		return nil
 	}
 
-	var iface PersonalNoteContentObjectUnion
 	switch collection {
-
 	case "motion":
-
 		builder := &motionBuilder{
-			builder: builder[motionBuilder, *motionBuilder, Motion]{
+			builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 				fetch: ds,
+				conv:  func(p *Motion) Motion { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -6123,31 +6385,34 @@ func (b *personalNoteContentObjectUnionBuilder) Preload(rel builderWrapperI) *pe
 
 func (b *personalNoteBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *personalNoteBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PersonalNote(ids ...int) *personalNoteBuilder {
 	return &personalNoteBuilder{
-		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote]{
+		builder: builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote, *PersonalNote]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PersonalNote) PersonalNote { return *p },
 		},
 	}
 }
@@ -6164,7 +6429,7 @@ type PointOfOrderCategory struct {
 }
 
 type pointOfOrderCategoryBuilder struct {
-	builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory]
+	builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory, *PointOfOrderCategory]
 }
 
 func (b *pointOfOrderCategoryBuilder) lazy(ds *Fetch, idI any) *PointOfOrderCategory {
@@ -6185,32 +6450,35 @@ func (b *pointOfOrderCategoryBuilder) Preload(rel builderWrapperI) *pointOfOrder
 
 func (b *pointOfOrderCategoryBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *pointOfOrderCategoryBuilder) SpeakerList() *speakerBuilder {
 	return &speakerBuilder{
-		builder: builder[speakerBuilder, *speakerBuilder, Speaker]{
+		builder: builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SpeakerIDs",
 			relField: "SpeakerList",
 			many:     true,
+			conv:     func(p *Speaker) Speaker { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PointOfOrderCategory(ids ...int) *pointOfOrderCategoryBuilder {
 	return &pointOfOrderCategoryBuilder{
-		builder: builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory]{
+		builder: builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory, *PointOfOrderCategory]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PointOfOrderCategory) PointOfOrderCategory { return *p },
 		},
 	}
 }
@@ -6237,8 +6505,8 @@ type Poll struct {
 	Visibility        string
 	VotedIDs          []int
 	BallotList        []PollBallot
-	Config            *PollConfigUnion
-	ContentObject     *PollContentObjectUnion
+	Config            PollConfigUnion
+	ContentObject     PollContentObjectUnion
 	EntitledGroupList []Group
 	Meeting           *Meeting
 	OptionList        []PollOption
@@ -6247,7 +6515,7 @@ type Poll struct {
 }
 
 type pollBuilder struct {
-	builder[pollBuilder, *pollBuilder, Poll]
+	builder[pollBuilder, *pollBuilder, Poll, *Poll]
 }
 
 func (b *pollBuilder) lazy(ds *Fetch, idI any) *Poll {
@@ -6282,23 +6550,25 @@ func (b *pollBuilder) Preload(rel builderWrapperI) *pollBuilder {
 
 func (b *pollBuilder) BallotList() *pollBallotBuilder {
 	return &pollBallotBuilder{
-		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot]{
+		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot, *PollBallot]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "BallotIDs",
 			relField: "BallotList",
 			many:     true,
+			conv:     func(p *PollBallot) PollBallot { return *p },
 		},
 	}
 }
 
 func (b *pollBuilder) Config() *pollConfigUnionBuilder {
 	return &pollConfigUnionBuilder{
-		builder: builder[pollConfigUnionBuilder, *pollConfigUnionBuilder, PollConfigUnion]{
+		builder: builder[pollConfigUnionBuilder, *pollConfigUnionBuilder, PollConfigUnion, PollConfigUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ConfigID",
 			relField: "Config",
+			conv:     func(u PollConfigUnion) PollConfigUnion { return u },
 		},
 	}
 }
@@ -6314,10 +6584,10 @@ func (*PollConfigRatingApproval) isPollConfigUnion() {}
 func (*PollConfigStvScottish) isPollConfigUnion()    {}
 
 type pollConfigUnionBuilder struct {
-	builder[pollConfigUnionBuilder, *pollConfigUnionBuilder, PollConfigUnion]
+	builder[pollConfigUnionBuilder, *pollConfigUnionBuilder, PollConfigUnion, PollConfigUnion]
 }
 
-func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
+func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) PollConfigUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -6333,64 +6603,47 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 		return nil
 	}
 
-	var iface PollConfigUnion
 	switch collection {
-
 	case "poll_config_approval":
-
 		builder := &pollConfigApprovalBuilder{
-			builder: builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval]{
+			builder: builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval, *PollConfigApproval]{
 				fetch: ds,
+				conv:  func(p *PollConfigApproval) PollConfigApproval { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "poll_config_selection":
-
 		builder := &pollConfigSelectionBuilder{
-			builder: builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection]{
+			builder: builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection, *PollConfigSelection]{
 				fetch: ds,
+				conv:  func(p *PollConfigSelection) PollConfigSelection { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "poll_config_rating_score":
-
 		builder := &pollConfigRatingScoreBuilder{
-			builder: builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore]{
+			builder: builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore, *PollConfigRatingScore]{
 				fetch: ds,
+				conv:  func(p *PollConfigRatingScore) PollConfigRatingScore { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "poll_config_rating_approval":
-
 		builder := &pollConfigRatingApprovalBuilder{
-			builder: builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval]{
+			builder: builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval, *PollConfigRatingApproval]{
 				fetch: ds,
+				conv:  func(p *PollConfigRatingApproval) PollConfigRatingApproval { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "poll_config_stv_scottish":
-
 		builder := &pollConfigStvScottishBuilder{
-			builder: builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish]{
+			builder: builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish, *PollConfigStvScottish]{
 				fetch: ds,
+				conv:  func(p *PollConfigStvScottish) PollConfigStvScottish { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -6403,11 +6656,12 @@ func (b *pollConfigUnionBuilder) Preload(rel builderWrapperI) *pollConfigUnionBu
 
 func (b *pollBuilder) ContentObject() *pollContentObjectUnionBuilder {
 	return &pollContentObjectUnionBuilder{
-		builder: builder[pollContentObjectUnionBuilder, *pollContentObjectUnionBuilder, PollContentObjectUnion]{
+		builder: builder[pollContentObjectUnionBuilder, *pollContentObjectUnionBuilder, PollContentObjectUnion, PollContentObjectUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ContentObjectID",
 			relField: "ContentObject",
+			conv:     func(u PollContentObjectUnion) PollContentObjectUnion { return u },
 		},
 	}
 }
@@ -6421,10 +6675,10 @@ func (*Assignment) isPollContentObjectUnion() {}
 func (*Topic) isPollContentObjectUnion()      {}
 
 type pollContentObjectUnionBuilder struct {
-	builder[pollContentObjectUnionBuilder, *pollContentObjectUnionBuilder, PollContentObjectUnion]
+	builder[pollContentObjectUnionBuilder, *pollContentObjectUnionBuilder, PollContentObjectUnion, PollContentObjectUnion]
 }
 
-func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObjectUnion {
+func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) PollContentObjectUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -6440,42 +6694,31 @@ func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObje
 		return nil
 	}
 
-	var iface PollContentObjectUnion
 	switch collection {
-
 	case "motion":
-
 		builder := &motionBuilder{
-			builder: builder[motionBuilder, *motionBuilder, Motion]{
+			builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 				fetch: ds,
+				conv:  func(p *Motion) Motion { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "assignment":
-
 		builder := &assignmentBuilder{
-			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 				fetch: ds,
+				conv:  func(p *Assignment) Assignment { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "topic":
-
 		builder := &topicBuilder{
-			builder: builder[topicBuilder, *topicBuilder, Topic]{
+			builder: builder[topicBuilder, *topicBuilder, Topic, *Topic]{
 				fetch: ds,
+				conv:  func(p *Topic) Topic { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -6488,68 +6731,74 @@ func (b *pollContentObjectUnionBuilder) Preload(rel builderWrapperI) *pollConten
 
 func (b *pollBuilder) EntitledGroupList() *groupBuilder {
 	return &groupBuilder{
-		builder: builder[groupBuilder, *groupBuilder, Group]{
+		builder: builder[groupBuilder, *groupBuilder, Group, *Group]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "EntitledGroupIDs",
 			relField: "EntitledGroupList",
 			many:     true,
+			conv:     func(p *Group) Group { return *p },
 		},
 	}
 }
 
 func (b *pollBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *pollBuilder) OptionList() *pollOptionBuilder {
 	return &pollOptionBuilder{
-		builder: builder[pollOptionBuilder, *pollOptionBuilder, PollOption]{
+		builder: builder[pollOptionBuilder, *pollOptionBuilder, PollOption, *PollOption]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OptionIDs",
 			relField: "OptionList",
 			many:     true,
+			conv:     func(p *PollOption) PollOption { return *p },
 		},
 	}
 }
 
 func (b *pollBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *pollBuilder) VotedList() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "VotedIDs",
 			relField: "VotedList",
 			many:     true,
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Poll(ids ...int) *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Poll) Poll { return *p },
 		},
 	}
 }
@@ -6569,7 +6818,7 @@ type PollBallot struct {
 }
 
 type pollBallotBuilder struct {
-	builder[pollBallotBuilder, *pollBallotBuilder, PollBallot]
+	builder[pollBallotBuilder, *pollBallotBuilder, PollBallot, *PollBallot]
 }
 
 func (b *pollBallotBuilder) lazy(ds *Fetch, idI any) *PollBallot {
@@ -6592,42 +6841,46 @@ func (b *pollBallotBuilder) Preload(rel builderWrapperI) *pollBallotBuilder {
 
 func (b *pollBallotBuilder) ActingMeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ActingMeetingUserID",
 			relField: "ActingMeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *pollBallotBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *pollBallotBuilder) RepresentedMeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "RepresentedMeetingUserID",
 			relField: "RepresentedMeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollBallot(ids ...int) *pollBallotBuilder {
 	return &pollBallotBuilder{
-		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot]{
+		builder: builder[pollBallotBuilder, *pollBallotBuilder, PollBallot, *PollBallot]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollBallot) PollBallot { return *p },
 		},
 	}
 }
@@ -6642,7 +6895,7 @@ type PollConfigApproval struct {
 }
 
 type pollConfigApprovalBuilder struct {
-	builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval]
+	builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval, *PollConfigApproval]
 }
 
 func (b *pollConfigApprovalBuilder) lazy(ds *Fetch, idI any) *PollConfigApproval {
@@ -6662,20 +6915,22 @@ func (b *pollConfigApprovalBuilder) Preload(rel builderWrapperI) *pollConfigAppr
 
 func (b *pollConfigApprovalBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollConfigApproval(ids ...int) *pollConfigApprovalBuilder {
 	return &pollConfigApprovalBuilder{
-		builder: builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval]{
+		builder: builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval, *PollConfigApproval]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollConfigApproval) PollConfigApproval { return *p },
 		},
 	}
 }
@@ -6692,7 +6947,7 @@ type PollConfigRatingApproval struct {
 }
 
 type pollConfigRatingApprovalBuilder struct {
-	builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval]
+	builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval, *PollConfigRatingApproval]
 }
 
 func (b *pollConfigRatingApprovalBuilder) lazy(ds *Fetch, idI any) *PollConfigRatingApproval {
@@ -6714,20 +6969,22 @@ func (b *pollConfigRatingApprovalBuilder) Preload(rel builderWrapperI) *pollConf
 
 func (b *pollConfigRatingApprovalBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollConfigRatingApproval(ids ...int) *pollConfigRatingApprovalBuilder {
 	return &pollConfigRatingApprovalBuilder{
-		builder: builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval]{
+		builder: builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval, *PollConfigRatingApproval]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollConfigRatingApproval) PollConfigRatingApproval { return *p },
 		},
 	}
 }
@@ -6746,7 +7003,7 @@ type PollConfigRatingScore struct {
 }
 
 type pollConfigRatingScoreBuilder struct {
-	builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore]
+	builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore, *PollConfigRatingScore]
 }
 
 func (b *pollConfigRatingScoreBuilder) lazy(ds *Fetch, idI any) *PollConfigRatingScore {
@@ -6770,20 +7027,22 @@ func (b *pollConfigRatingScoreBuilder) Preload(rel builderWrapperI) *pollConfigR
 
 func (b *pollConfigRatingScoreBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollConfigRatingScore(ids ...int) *pollConfigRatingScoreBuilder {
 	return &pollConfigRatingScoreBuilder{
-		builder: builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore]{
+		builder: builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore, *PollConfigRatingScore]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollConfigRatingScore) PollConfigRatingScore { return *p },
 		},
 	}
 }
@@ -6802,7 +7061,7 @@ type PollConfigSelection struct {
 }
 
 type pollConfigSelectionBuilder struct {
-	builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection]
+	builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection, *PollConfigSelection]
 }
 
 func (b *pollConfigSelectionBuilder) lazy(ds *Fetch, idI any) *PollConfigSelection {
@@ -6826,20 +7085,22 @@ func (b *pollConfigSelectionBuilder) Preload(rel builderWrapperI) *pollConfigSel
 
 func (b *pollConfigSelectionBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollConfigSelection(ids ...int) *pollConfigSelectionBuilder {
 	return &pollConfigSelectionBuilder{
-		builder: builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection]{
+		builder: builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection, *PollConfigSelection]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollConfigSelection) PollConfigSelection { return *p },
 		},
 	}
 }
@@ -6853,7 +7114,7 @@ type PollConfigStvScottish struct {
 }
 
 type pollConfigStvScottishBuilder struct {
-	builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish]
+	builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish, *PollConfigStvScottish]
 }
 
 func (b *pollConfigStvScottishBuilder) lazy(ds *Fetch, idI any) *PollConfigStvScottish {
@@ -6872,20 +7133,22 @@ func (b *pollConfigStvScottishBuilder) Preload(rel builderWrapperI) *pollConfigS
 
 func (b *pollConfigStvScottishBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollConfigStvScottish(ids ...int) *pollConfigStvScottishBuilder {
 	return &pollConfigStvScottishBuilder{
-		builder: builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish]{
+		builder: builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish, *PollConfigStvScottish]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollConfigStvScottish) PollConfigStvScottish { return *p },
 		},
 	}
 }
@@ -6902,7 +7165,7 @@ type PollOption struct {
 }
 
 type pollOptionBuilder struct {
-	builder[pollOptionBuilder, *pollOptionBuilder, PollOption]
+	builder[pollOptionBuilder, *pollOptionBuilder, PollOption, *PollOption]
 }
 
 func (b *pollOptionBuilder) lazy(ds *Fetch, idI any) *PollOption {
@@ -6923,31 +7186,34 @@ func (b *pollOptionBuilder) Preload(rel builderWrapperI) *pollOptionBuilder {
 
 func (b *pollOptionBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *pollOptionBuilder) Poll() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollID",
 			relField: "Poll",
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (r *Fetch) PollOption(ids ...int) *pollOptionBuilder {
 	return &pollOptionBuilder{
-		builder: builder[pollOptionBuilder, *pollOptionBuilder, PollOption]{
+		builder: builder[pollOptionBuilder, *pollOptionBuilder, PollOption, *PollOption]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *PollOption) PollOption { return *p },
 		},
 	}
 }
@@ -6964,7 +7230,7 @@ type Projection struct {
 	Stable             bool
 	Type               string
 	Weight             int
-	ContentObject      *ProjectionContentObjectUnion
+	ContentObject      ProjectionContentObjectUnion
 	CurrentProjector   *dsfetch.Maybe[Projector]
 	HistoryProjector   *dsfetch.Maybe[Projector]
 	Meeting            *Meeting
@@ -6972,7 +7238,7 @@ type Projection struct {
 }
 
 type projectionBuilder struct {
-	builder[projectionBuilder, *projectionBuilder, Projection]
+	builder[projectionBuilder, *projectionBuilder, Projection, *Projection]
 }
 
 func (b *projectionBuilder) lazy(ds *Fetch, idI any) *Projection {
@@ -6998,11 +7264,12 @@ func (b *projectionBuilder) Preload(rel builderWrapperI) *projectionBuilder {
 
 func (b *projectionBuilder) ContentObject() *projectionContentObjectUnionBuilder {
 	return &projectionContentObjectUnionBuilder{
-		builder: builder[projectionContentObjectUnionBuilder, *projectionContentObjectUnionBuilder, ProjectionContentObjectUnion]{
+		builder: builder[projectionContentObjectUnionBuilder, *projectionContentObjectUnionBuilder, ProjectionContentObjectUnion, ProjectionContentObjectUnion]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ContentObjectID",
 			relField: "ContentObject",
+			conv:     func(u ProjectionContentObjectUnion) ProjectionContentObjectUnion { return u },
 		},
 	}
 }
@@ -7024,10 +7291,10 @@ func (*ProjectorMessage) isProjectionContentObjectUnion()   {}
 func (*ProjectorCountdown) isProjectionContentObjectUnion() {}
 
 type projectionContentObjectUnionBuilder struct {
-	builder[projectionContentObjectUnionBuilder, *projectionContentObjectUnionBuilder, ProjectionContentObjectUnion]
+	builder[projectionContentObjectUnionBuilder, *projectionContentObjectUnionBuilder, ProjectionContentObjectUnion, ProjectionContentObjectUnion]
 }
 
-func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ProjectionContentObjectUnion {
+func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) ProjectionContentObjectUnion {
 	fqid, ok := id.(string)
 	if !ok {
 		return nil
@@ -7043,130 +7310,95 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 		return nil
 	}
 
-	var iface ProjectionContentObjectUnion
 	switch collection {
-
 	case "meeting":
-
 		builder := &meetingBuilder{
-			builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+			builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 				fetch: ds,
+				conv:  func(p *Meeting) Meeting { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "motion":
-
 		builder := &motionBuilder{
-			builder: builder[motionBuilder, *motionBuilder, Motion]{
+			builder: builder[motionBuilder, *motionBuilder, Motion, *Motion]{
 				fetch: ds,
+				conv:  func(p *Motion) Motion { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "meeting_mediafile":
-
 		builder := &meetingMediafileBuilder{
-			builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+			builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 				fetch: ds,
+				conv:  func(p *MeetingMediafile) MeetingMediafile { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "list_of_speakers":
-
 		builder := &listOfSpeakersBuilder{
-			builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+			builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 				fetch: ds,
+				conv:  func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "motion_block":
-
 		builder := &motionBlockBuilder{
-			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock, *MotionBlock]{
 				fetch: ds,
+				conv:  func(p *MotionBlock) MotionBlock { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "assignment":
-
 		builder := &assignmentBuilder{
-			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment, *Assignment]{
 				fetch: ds,
+				conv:  func(p *Assignment) Assignment { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "agenda_item":
-
 		builder := &agendaItemBuilder{
-			builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+			builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 				fetch: ds,
+				conv:  func(p *AgendaItem) AgendaItem { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "topic":
-
 		builder := &topicBuilder{
-			builder: builder[topicBuilder, *topicBuilder, Topic]{
+			builder: builder[topicBuilder, *topicBuilder, Topic, *Topic]{
 				fetch: ds,
+				conv:  func(p *Topic) Topic { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "poll":
-
 		builder := &pollBuilder{
-			builder: builder[pollBuilder, *pollBuilder, Poll]{
+			builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 				fetch: ds,
+				conv:  func(p *Poll) Poll { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "projector_message":
-
 		builder := &projectorMessageBuilder{
-			builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage]{
+			builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage, *ProjectorMessage]{
 				fetch: ds,
+				conv:  func(p *ProjectorMessage) ProjectorMessage { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	case "projector_countdown":
-
 		builder := &projectorCountdownBuilder{
-			builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]{
+			builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown, *ProjectorCountdown]{
 				fetch: ds,
+				conv:  func(p *ProjectorCountdown) ProjectorCountdown { return *p },
 			},
 		}
-		result := builder.lazy(ds, intId)
-		iface = result
-		return &iface
-
+		return builder.lazy(ds, intId)
 	}
 
 	return nil
@@ -7179,53 +7411,58 @@ func (b *projectionContentObjectUnionBuilder) Preload(rel builderWrapperI) *proj
 
 func (b *projectionBuilder) CurrentProjector() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CurrentProjectorID",
 			relField: "CurrentProjector",
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *projectionBuilder) HistoryProjector() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HistoryProjectorID",
 			relField: "HistoryProjector",
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (b *projectionBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectionBuilder) PreviewProjector() *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PreviewProjectorID",
 			relField: "PreviewProjector",
+			conv:     func(p *Projector) Projector { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Projection(ids ...int) *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Projection) Projection { return *p },
 		},
 	}
 }
@@ -7295,7 +7532,7 @@ type Projector struct {
 }
 
 type projectorBuilder struct {
-	builder[projectorBuilder, *projectorBuilder, Projector]
+	builder[projectorBuilder, *projectorBuilder, Projector, *Projector]
 }
 
 func (b *projectorBuilder) lazy(ds *Fetch, idI any) *Projector {
@@ -7352,221 +7589,241 @@ func (b *projectorBuilder) Preload(rel builderWrapperI) *projectorBuilder {
 
 func (b *projectorBuilder) CurrentProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CurrentProjectionIDs",
 			relField: "CurrentProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) HistoryProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HistoryProjectionIDs",
 			relField: "HistoryProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) PreviewProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PreviewProjectionIDs",
 			relField: "PreviewProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForAgendaItemListInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForAgendaItemListInMeetingID",
 			relField: "UsedAsDefaultProjectorForAgendaItemListInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForAmendmentInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForAmendmentInMeetingID",
 			relField: "UsedAsDefaultProjectorForAmendmentInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForAssignmentInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForAssignmentInMeetingID",
 			relField: "UsedAsDefaultProjectorForAssignmentInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForAssignmentPollInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForAssignmentPollInMeetingID",
 			relField: "UsedAsDefaultProjectorForAssignmentPollInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForCountdownInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForCountdownInMeetingID",
 			relField: "UsedAsDefaultProjectorForCountdownInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForCurrentLosInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForCurrentLosInMeetingID",
 			relField: "UsedAsDefaultProjectorForCurrentLosInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForListOfSpeakersInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForListOfSpeakersInMeetingID",
 			relField: "UsedAsDefaultProjectorForListOfSpeakersInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForMediafileInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForMediafileInMeetingID",
 			relField: "UsedAsDefaultProjectorForMediafileInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForMessageInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForMessageInMeetingID",
 			relField: "UsedAsDefaultProjectorForMessageInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForMotionBlockInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForMotionBlockInMeetingID",
 			relField: "UsedAsDefaultProjectorForMotionBlockInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForMotionInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForMotionInMeetingID",
 			relField: "UsedAsDefaultProjectorForMotionInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForMotionPollInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForMotionPollInMeetingID",
 			relField: "UsedAsDefaultProjectorForMotionPollInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForPollInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForPollInMeetingID",
 			relField: "UsedAsDefaultProjectorForPollInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsDefaultProjectorForTopicInMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsDefaultProjectorForTopicInMeetingID",
 			relField: "UsedAsDefaultProjectorForTopicInMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorBuilder) UsedAsReferenceProjectorMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsReferenceProjectorMeetingID",
 			relField: "UsedAsReferenceProjectorMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Projector(ids ...int) *projectorBuilder {
 	return &projectorBuilder{
-		builder: builder[projectorBuilder, *projectorBuilder, Projector]{
+		builder: builder[projectorBuilder, *projectorBuilder, Projector, *Projector]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Projector) Projector { return *p },
 		},
 	}
 }
@@ -7590,7 +7847,7 @@ type ProjectorCountdown struct {
 }
 
 type projectorCountdownBuilder struct {
-	builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]
+	builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown, *ProjectorCountdown]
 }
 
 func (b *projectorCountdownBuilder) lazy(ds *Fetch, idI any) *ProjectorCountdown {
@@ -7616,54 +7873,59 @@ func (b *projectorCountdownBuilder) Preload(rel builderWrapperI) *projectorCount
 
 func (b *projectorCountdownBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorCountdownBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (b *projectorCountdownBuilder) UsedAsListOfSpeakersCountdownMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsListOfSpeakersCountdownMeetingID",
 			relField: "UsedAsListOfSpeakersCountdownMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorCountdownBuilder) UsedAsPollCountdownMeeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "UsedAsPollCountdownMeetingID",
 			relField: "UsedAsPollCountdownMeeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (r *Fetch) ProjectorCountdown(ids ...int) *projectorCountdownBuilder {
 	return &projectorCountdownBuilder{
-		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]{
+		builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown, *ProjectorCountdown]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ProjectorCountdown) ProjectorCountdown { return *p },
 		},
 	}
 }
@@ -7679,7 +7941,7 @@ type ProjectorMessage struct {
 }
 
 type projectorMessageBuilder struct {
-	builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage]
+	builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage, *ProjectorMessage]
 }
 
 func (b *projectorMessageBuilder) lazy(ds *Fetch, idI any) *ProjectorMessage {
@@ -7699,32 +7961,35 @@ func (b *projectorMessageBuilder) Preload(rel builderWrapperI) *projectorMessage
 
 func (b *projectorMessageBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *projectorMessageBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (r *Fetch) ProjectorMessage(ids ...int) *projectorMessageBuilder {
 	return &projectorMessageBuilder{
-		builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage]{
+		builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage, *ProjectorMessage]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *ProjectorMessage) ProjectorMessage { return *p },
 		},
 	}
 }
@@ -7755,7 +8020,7 @@ type Speaker struct {
 }
 
 type speakerBuilder struct {
-	builder[speakerBuilder, *speakerBuilder, Speaker]
+	builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]
 }
 
 func (b *speakerBuilder) lazy(ds *Fetch, idI any) *Speaker {
@@ -7787,64 +8052,70 @@ func (b *speakerBuilder) Preload(rel builderWrapperI) *speakerBuilder {
 
 func (b *speakerBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *speakerBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *speakerBuilder) MeetingUser() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserID",
 			relField: "MeetingUser",
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *speakerBuilder) PointOfOrderCategory() *pointOfOrderCategoryBuilder {
 	return &pointOfOrderCategoryBuilder{
-		builder: builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory]{
+		builder: builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory, *PointOfOrderCategory]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PointOfOrderCategoryID",
 			relField: "PointOfOrderCategory",
+			conv:     func(p *PointOfOrderCategory) PointOfOrderCategory { return *p },
 		},
 	}
 }
 
 func (b *speakerBuilder) StructureLevelListOfSpeakers() *structureLevelListOfSpeakersBuilder {
 	return &structureLevelListOfSpeakersBuilder{
-		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]{
+		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers, *StructureLevelListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelListOfSpeakersID",
 			relField: "StructureLevelListOfSpeakers",
+			conv:     func(p *StructureLevelListOfSpeakers) StructureLevelListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Speaker(ids ...int) *speakerBuilder {
 	return &speakerBuilder{
-		builder: builder[speakerBuilder, *speakerBuilder, Speaker]{
+		builder: builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Speaker) Speaker { return *p },
 		},
 	}
 }
@@ -7864,7 +8135,7 @@ type StructureLevel struct {
 }
 
 type structureLevelBuilder struct {
-	builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel]
+	builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel, *StructureLevel]
 }
 
 func (b *structureLevelBuilder) lazy(ds *Fetch, idI any) *StructureLevel {
@@ -7887,44 +8158,48 @@ func (b *structureLevelBuilder) Preload(rel builderWrapperI) *structureLevelBuil
 
 func (b *structureLevelBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *structureLevelBuilder) MeetingUserList() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserIDs",
 			relField: "MeetingUserList",
 			many:     true,
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *structureLevelBuilder) StructureLevelListOfSpeakersList() *structureLevelListOfSpeakersBuilder {
 	return &structureLevelListOfSpeakersBuilder{
-		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]{
+		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers, *StructureLevelListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelListOfSpeakersIDs",
 			relField: "StructureLevelListOfSpeakersList",
 			many:     true,
+			conv:     func(p *StructureLevelListOfSpeakers) StructureLevelListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (r *Fetch) StructureLevel(ids ...int) *structureLevelBuilder {
 	return &structureLevelBuilder{
-		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel]{
+		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel, *StructureLevel]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *StructureLevel) StructureLevel { return *p },
 		},
 	}
 }
@@ -7947,7 +8222,7 @@ type StructureLevelListOfSpeakers struct {
 }
 
 type structureLevelListOfSpeakersBuilder struct {
-	builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]
+	builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers, *StructureLevelListOfSpeakers]
 }
 
 func (b *structureLevelListOfSpeakersBuilder) lazy(ds *Fetch, idI any) *StructureLevelListOfSpeakers {
@@ -7972,54 +8247,59 @@ func (b *structureLevelListOfSpeakersBuilder) Preload(rel builderWrapperI) *stru
 
 func (b *structureLevelListOfSpeakersBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *structureLevelListOfSpeakersBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *structureLevelListOfSpeakersBuilder) SpeakerList() *speakerBuilder {
 	return &speakerBuilder{
-		builder: builder[speakerBuilder, *speakerBuilder, Speaker]{
+		builder: builder[speakerBuilder, *speakerBuilder, Speaker, *Speaker]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "SpeakerIDs",
 			relField: "SpeakerList",
 			many:     true,
+			conv:     func(p *Speaker) Speaker { return *p },
 		},
 	}
 }
 
 func (b *structureLevelListOfSpeakersBuilder) StructureLevel() *structureLevelBuilder {
 	return &structureLevelBuilder{
-		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel]{
+		builder: builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel, *StructureLevel]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "StructureLevelID",
 			relField: "StructureLevel",
+			conv:     func(p *StructureLevel) StructureLevel { return *p },
 		},
 	}
 }
 
 func (r *Fetch) StructureLevelListOfSpeakers(ids ...int) *structureLevelListOfSpeakersBuilder {
 	return &structureLevelListOfSpeakersBuilder{
-		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]{
+		builder: builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers, *StructureLevelListOfSpeakers]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *StructureLevelListOfSpeakers) StructureLevelListOfSpeakers { return *p },
 		},
 	}
 }
@@ -8034,7 +8314,7 @@ type Tag struct {
 }
 
 type tagBuilder struct {
-	builder[tagBuilder, *tagBuilder, Tag]
+	builder[tagBuilder, *tagBuilder, Tag, *Tag]
 }
 
 func (b *tagBuilder) lazy(ds *Fetch, idI any) *Tag {
@@ -8054,20 +8334,22 @@ func (b *tagBuilder) Preload(rel builderWrapperI) *tagBuilder {
 
 func (b *tagBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Tag(ids ...int) *tagBuilder {
 	return &tagBuilder{
-		builder: builder[tagBuilder, *tagBuilder, Tag]{
+		builder: builder[tagBuilder, *tagBuilder, Tag, *Tag]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Tag) Tag { return *p },
 		},
 	}
 }
@@ -8129,7 +8411,7 @@ type Theme struct {
 }
 
 type themeBuilder struct {
-	builder[themeBuilder, *themeBuilder, Theme]
+	builder[themeBuilder, *themeBuilder, Theme, *Theme]
 }
 
 func (b *themeBuilder) lazy(ds *Fetch, idI any) *Theme {
@@ -8195,31 +8477,34 @@ func (b *themeBuilder) Preload(rel builderWrapperI) *themeBuilder {
 
 func (b *themeBuilder) Organization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationID",
 			relField: "Organization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (b *themeBuilder) ThemeForOrganization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ThemeForOrganizationID",
 			relField: "ThemeForOrganization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Theme(ids ...int) *themeBuilder {
 	return &themeBuilder{
-		builder: builder[themeBuilder, *themeBuilder, Theme]{
+		builder: builder[themeBuilder, *themeBuilder, Theme, *Theme]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Theme) Theme { return *p },
 		},
 	}
 }
@@ -8245,7 +8530,7 @@ type Topic struct {
 }
 
 type topicBuilder struct {
-	builder[topicBuilder, *topicBuilder, Topic]
+	builder[topicBuilder, *topicBuilder, Topic, *Topic]
 }
 
 func (b *topicBuilder) lazy(ds *Fetch, idI any) *Topic {
@@ -8271,78 +8556,85 @@ func (b *topicBuilder) Preload(rel builderWrapperI) *topicBuilder {
 
 func (b *topicBuilder) AgendaItem() *agendaItemBuilder {
 	return &agendaItemBuilder{
-		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+		builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem, *AgendaItem]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AgendaItemID",
 			relField: "AgendaItem",
+			conv:     func(p *AgendaItem) AgendaItem { return *p },
 		},
 	}
 }
 
 func (b *topicBuilder) AttachmentMeetingMediafileList() *meetingMediafileBuilder {
 	return &meetingMediafileBuilder{
-		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+		builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile, *MeetingMediafile]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "AttachmentMeetingMediafileIDs",
 			relField: "AttachmentMeetingMediafileList",
 			many:     true,
+			conv:     func(p *MeetingMediafile) MeetingMediafile { return *p },
 		},
 	}
 }
 
 func (b *topicBuilder) ListOfSpeakers() *listOfSpeakersBuilder {
 	return &listOfSpeakersBuilder{
-		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+		builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers, *ListOfSpeakers]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ListOfSpeakersID",
 			relField: "ListOfSpeakers",
+			conv:     func(p *ListOfSpeakers) ListOfSpeakers { return *p },
 		},
 	}
 }
 
 func (b *topicBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingID",
 			relField: "Meeting",
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *topicBuilder) PollList() *pollBuilder {
 	return &pollBuilder{
-		builder: builder[pollBuilder, *pollBuilder, Poll]{
+		builder: builder[pollBuilder, *pollBuilder, Poll, *Poll]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "PollIDs",
 			relField: "PollList",
 			many:     true,
+			conv:     func(p *Poll) Poll { return *p },
 		},
 	}
 }
 
 func (b *topicBuilder) ProjectionList() *projectionBuilder {
 	return &projectionBuilder{
-		builder: builder[projectionBuilder, *projectionBuilder, Projection]{
+		builder: builder[projectionBuilder, *projectionBuilder, Projection, *Projection]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "ProjectionIDs",
 			relField: "ProjectionList",
 			many:     true,
+			conv:     func(p *Projection) Projection { return *p },
 		},
 	}
 }
 
 func (r *Fetch) Topic(ids ...int) *topicBuilder {
 	return &topicBuilder{
-		builder: builder[topicBuilder, *topicBuilder, Topic]{
+		builder: builder[topicBuilder, *topicBuilder, Topic, *Topic]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *Topic) Topic { return *p },
 		},
 	}
 }
@@ -8392,7 +8684,7 @@ type User struct {
 }
 
 type userBuilder struct {
-	builder[userBuilder, *userBuilder, User]
+	builder[userBuilder, *userBuilder, User, *User]
 }
 
 func (b *userBuilder) lazy(ds *Fetch, idI any) *User {
@@ -8438,126 +8730,137 @@ func (b *userBuilder) Preload(rel builderWrapperI) *userBuilder {
 
 func (b *userBuilder) CommitteeList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CommitteeIDs",
 			relField: "CommitteeList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) CommitteeManagementList() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "CommitteeManagementIDs",
 			relField: "CommitteeManagementList",
 			many:     true,
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) Gender() *genderBuilder {
 	return &genderBuilder{
-		builder: builder[genderBuilder, *genderBuilder, Gender]{
+		builder: builder[genderBuilder, *genderBuilder, Gender, *Gender]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "GenderID",
 			relField: "Gender",
+			conv:     func(p *Gender) Gender { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) HistoryEntryList() *historyEntryBuilder {
 	return &historyEntryBuilder{
-		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]{
+		builder: builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry, *HistoryEntry]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HistoryEntryIDs",
 			relField: "HistoryEntryList",
 			many:     true,
+			conv:     func(p *HistoryEntry) HistoryEntry { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) HistoryPositionList() *historyPositionBuilder {
 	return &historyPositionBuilder{
-		builder: builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition]{
+		builder: builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition, *HistoryPosition]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HistoryPositionIDs",
 			relField: "HistoryPositionList",
 			many:     true,
+			conv:     func(p *HistoryPosition) HistoryPosition { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) HomeCommittee() *committeeBuilder {
 	return &committeeBuilder{
-		builder: builder[committeeBuilder, *committeeBuilder, Committee]{
+		builder: builder[committeeBuilder, *committeeBuilder, Committee, *Committee]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "HomeCommitteeID",
 			relField: "HomeCommittee",
+			conv:     func(p *Committee) Committee { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) IsPresentInMeetingList() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "IsPresentInMeetingIDs",
 			relField: "IsPresentInMeetingList",
 			many:     true,
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) MeetingList() *meetingBuilder {
 	return &meetingBuilder{
-		builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+		builder: builder[meetingBuilder, *meetingBuilder, Meeting, *Meeting]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingIDs",
 			relField: "MeetingList",
 			many:     true,
+			conv:     func(p *Meeting) Meeting { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) MeetingUserList() *meetingUserBuilder {
 	return &meetingUserBuilder{
-		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]{
+		builder: builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser, *MeetingUser]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "MeetingUserIDs",
 			relField: "MeetingUserList",
 			many:     true,
+			conv:     func(p *MeetingUser) MeetingUser { return *p },
 		},
 	}
 }
 
 func (b *userBuilder) Organization() *organizationBuilder {
 	return &organizationBuilder{
-		builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+		builder: builder[organizationBuilder, *organizationBuilder, Organization, *Organization]{
 			fetch:    b.fetch,
 			parent:   b,
 			idField:  "OrganizationID",
 			relField: "Organization",
+			conv:     func(p *Organization) Organization { return *p },
 		},
 	}
 }
 
 func (r *Fetch) User(ids ...int) *userBuilder {
 	return &userBuilder{
-		builder: builder[userBuilder, *userBuilder, User]{
+		builder: builder[userBuilder, *userBuilder, User, *User]{
 			ids:   ids,
 			fetch: r,
+			conv:  func(p *User) User { return *p },
 		},
 	}
 }

--- a/datastore/dsmodels/models_generated.go
+++ b/datastore/dsmodels/models_generated.go
@@ -3,6 +3,10 @@ package dsmodels
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
+	"unsafe"
+
 	"github.com/OpenSlides/openslides-go/datastore/dsfetch"
 	"github.com/shopspring/decimal"
 )
@@ -22,7 +26,8 @@ type actionWorkerBuilder struct {
 	builder[actionWorkerBuilder, *actionWorkerBuilder, ActionWorker]
 }
 
-func (b *actionWorkerBuilder) lazy(ds *Fetch, id int) *ActionWorker {
+func (b *actionWorkerBuilder) lazy(ds *Fetch, idI any) *ActionWorker {
+	id := idI.(int)
 	c := ActionWorker{}
 	ds.ActionWorker_Created(id).Lazy(&c.Created)
 	ds.ActionWorker_ID(id).Lazy(&c.ID)
@@ -47,15 +52,6 @@ func (r *Fetch) ActionWorker(ids ...int) *actionWorkerBuilder {
 		},
 	}
 }
-
-type AgendaItemContentObjectUnion interface {
-	isAgendaItemContentObjectUnion()
-}
-
-func (*Motion) isAgendaItemContentObjectUnion()      {}
-func (*MotionBlock) isAgendaItemContentObjectUnion() {}
-func (*Assignment) isAgendaItemContentObjectUnion()  {}
-func (*Topic) isAgendaItemContentObjectUnion()       {}
 
 // AgendaItem has all fields from agenda_item.
 type AgendaItem struct {
@@ -87,7 +83,8 @@ type agendaItemBuilder struct {
 	builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]
 }
 
-func (b *agendaItemBuilder) lazy(ds *Fetch, id int) *AgendaItem {
+func (b *agendaItemBuilder) lazy(ds *Fetch, idI any) *AgendaItem {
+	id := idI.(int)
 	c := AgendaItem{}
 	ds.AgendaItem_ChildIDs(id).Lazy(&c.ChildIDs)
 	ds.AgendaItem_Closed(id).Lazy(&c.Closed)
@@ -125,7 +122,97 @@ func (b *agendaItemBuilder) ChildList() *agendaItemBuilder {
 	}
 }
 
-// TODO: func (b *agendaItemBuilder) ContentObject()
+func (b *agendaItemBuilder) ContentObject() *agendaItemContentObjectUnionBuilder {
+	return &agendaItemContentObjectUnionBuilder{
+		builder: builder[agendaItemContentObjectUnionBuilder, *agendaItemContentObjectUnionBuilder, AgendaItemContentObjectUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ContentObjectID",
+			relField: "ContentObject",
+		},
+	}
+}
+
+type AgendaItemContentObjectUnion interface {
+	isAgendaItemContentObjectUnion()
+}
+
+func (*Motion) isAgendaItemContentObjectUnion()      {}
+func (*MotionBlock) isAgendaItemContentObjectUnion() {}
+func (*Assignment) isAgendaItemContentObjectUnion()  {}
+func (*Topic) isAgendaItemContentObjectUnion()       {}
+
+type agendaItemContentObjectUnionBuilder struct {
+	builder[agendaItemContentObjectUnionBuilder, *agendaItemContentObjectUnionBuilder, AgendaItemContentObjectUnion]
+}
+
+func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaItemContentObjectUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "motion":
+
+		builder := &motionBuilder{
+			builder: builder[motionBuilder, *motionBuilder, Motion]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+
+	case "motion_block":
+
+		builder := &motionBlockBuilder{
+			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+
+	case "assignment":
+
+		builder := &assignmentBuilder{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+
+	case "topic":
+
+		builder := &topicBuilder{
+			builder: builder[topicBuilder, *topicBuilder, Topic]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *agendaItemContentObjectUnionBuilder) Preload(rel builderWrapperI) *agendaItemContentObjectUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *agendaItemBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
@@ -216,7 +303,8 @@ type assignmentBuilder struct {
 	builder[assignmentBuilder, *assignmentBuilder, Assignment]
 }
 
-func (b *assignmentBuilder) lazy(ds *Fetch, id int) *Assignment {
+func (b *assignmentBuilder) lazy(ds *Fetch, idI any) *Assignment {
+	id := idI.(int)
 	c := Assignment{}
 	ds.Assignment_AgendaItemID(id).Lazy(&c.AgendaItemID)
 	ds.Assignment_AttachmentMeetingMediafileIDs(id).Lazy(&c.AttachmentMeetingMediafileIDs)
@@ -373,7 +461,8 @@ type assignmentCandidateBuilder struct {
 	builder[assignmentCandidateBuilder, *assignmentCandidateBuilder, AssignmentCandidate]
 }
 
-func (b *assignmentCandidateBuilder) lazy(ds *Fetch, id int) *AssignmentCandidate {
+func (b *assignmentCandidateBuilder) lazy(ds *Fetch, idI any) *AssignmentCandidate {
+	id := idI.(int)
 	c := AssignmentCandidate{}
 	ds.AssignmentCandidate_AssignmentID(id).Lazy(&c.AssignmentID)
 	ds.AssignmentCandidate_ID(id).Lazy(&c.ID)
@@ -449,7 +538,8 @@ type chatGroupBuilder struct {
 	builder[chatGroupBuilder, *chatGroupBuilder, ChatGroup]
 }
 
-func (b *chatGroupBuilder) lazy(ds *Fetch, id int) *ChatGroup {
+func (b *chatGroupBuilder) lazy(ds *Fetch, idI any) *ChatGroup {
+	id := idI.(int)
 	c := ChatGroup{}
 	ds.ChatGroup_ChatMessageIDs(id).Lazy(&c.ChatMessageIDs)
 	ds.ChatGroup_ID(id).Lazy(&c.ID)
@@ -539,7 +629,8 @@ type chatMessageBuilder struct {
 	builder[chatMessageBuilder, *chatMessageBuilder, ChatMessage]
 }
 
-func (b *chatMessageBuilder) lazy(ds *Fetch, id int) *ChatMessage {
+func (b *chatMessageBuilder) lazy(ds *Fetch, idI any) *ChatMessage {
+	id := idI.(int)
 	c := ChatMessage{}
 	ds.ChatMessage_ChatGroupID(id).Lazy(&c.ChatGroupID)
 	ds.ChatMessage_Content(id).Lazy(&c.Content)
@@ -635,7 +726,8 @@ type committeeBuilder struct {
 	builder[committeeBuilder, *committeeBuilder, Committee]
 }
 
-func (b *committeeBuilder) lazy(ds *Fetch, id int) *Committee {
+func (b *committeeBuilder) lazy(ds *Fetch, idI any) *Committee {
+	id := idI.(int)
 	c := Committee{}
 	ds.Committee_AllChildIDs(id).Lazy(&c.AllChildIDs)
 	ds.Committee_AllParentIDs(id).Lazy(&c.AllParentIDs)
@@ -838,7 +930,8 @@ type genderBuilder struct {
 	builder[genderBuilder, *genderBuilder, Gender]
 }
 
-func (b *genderBuilder) lazy(ds *Fetch, id int) *Gender {
+func (b *genderBuilder) lazy(ds *Fetch, idI any) *Gender {
+	id := idI.(int)
 	c := Gender{}
 	ds.Gender_ID(id).Lazy(&c.ID)
 	ds.Gender_Name(id).Lazy(&c.Name)
@@ -929,7 +1022,8 @@ type groupBuilder struct {
 	builder[groupBuilder, *groupBuilder, Group]
 }
 
-func (b *groupBuilder) lazy(ds *Fetch, id int) *Group {
+func (b *groupBuilder) lazy(ds *Fetch, idI any) *Group {
+	id := idI.(int)
 	c := Group{}
 	ds.Group_AdminGroupForMeetingID(id).Lazy(&c.AdminGroupForMeetingID)
 	ds.Group_AnonymousGroupForMeetingID(id).Lazy(&c.AnonymousGroupForMeetingID)
@@ -1153,14 +1247,6 @@ func (r *Fetch) Group(ids ...int) *groupBuilder {
 	}
 }
 
-type HistoryEntryModelUnion interface {
-	isHistoryEntryModelUnion()
-}
-
-func (*User) isHistoryEntryModelUnion()       {}
-func (*Motion) isHistoryEntryModelUnion()     {}
-func (*Assignment) isHistoryEntryModelUnion() {}
-
 // HistoryEntry has all fields from history_entry.
 type HistoryEntry struct {
 	Entries         []string
@@ -1178,7 +1264,8 @@ type historyEntryBuilder struct {
 	builder[historyEntryBuilder, *historyEntryBuilder, HistoryEntry]
 }
 
-func (b *historyEntryBuilder) lazy(ds *Fetch, id int) *HistoryEntry {
+func (b *historyEntryBuilder) lazy(ds *Fetch, idI any) *HistoryEntry {
+	id := idI.(int)
 	c := HistoryEntry{}
 	ds.HistoryEntry_Entries(id).Lazy(&c.Entries)
 	ds.HistoryEntry_ID(id).Lazy(&c.ID)
@@ -1205,7 +1292,86 @@ func (b *historyEntryBuilder) Meeting() *meetingBuilder {
 	}
 }
 
-// TODO: func (b *historyEntryBuilder) Model()
+func (b *historyEntryBuilder) Model() *historyEntryModelUnionBuilder {
+	return &historyEntryModelUnionBuilder{
+		builder: builder[historyEntryModelUnionBuilder, *historyEntryModelUnionBuilder, HistoryEntryModelUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ModelID",
+			relField: "Model",
+		},
+	}
+}
+
+type HistoryEntryModelUnion interface {
+	isHistoryEntryModelUnion()
+}
+
+func (*User) isHistoryEntryModelUnion()       {}
+func (*Motion) isHistoryEntryModelUnion()     {}
+func (*Assignment) isHistoryEntryModelUnion() {}
+
+type historyEntryModelUnionBuilder struct {
+	builder[historyEntryModelUnionBuilder, *historyEntryModelUnionBuilder, HistoryEntryModelUnion]
+}
+
+func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryModelUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "user":
+
+		builder := &userBuilder{
+			builder: builder[userBuilder, *userBuilder, User]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*HistoryEntryModelUnion)(unsafe.Pointer(result))
+
+	case "motion":
+
+		builder := &motionBuilder{
+			builder: builder[motionBuilder, *motionBuilder, Motion]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*HistoryEntryModelUnion)(unsafe.Pointer(result))
+
+	case "assignment":
+
+		builder := &assignmentBuilder{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*HistoryEntryModelUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *historyEntryModelUnionBuilder) Preload(rel builderWrapperI) *historyEntryModelUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *historyEntryBuilder) Position() *historyPositionBuilder {
 	return &historyPositionBuilder{
@@ -1242,7 +1408,8 @@ type historyPositionBuilder struct {
 	builder[historyPositionBuilder, *historyPositionBuilder, HistoryPosition]
 }
 
-func (b *historyPositionBuilder) lazy(ds *Fetch, id int) *HistoryPosition {
+func (b *historyPositionBuilder) lazy(ds *Fetch, idI any) *HistoryPosition {
+	id := idI.(int)
 	c := HistoryPosition{}
 	ds.HistoryPosition_EntryIDs(id).Lazy(&c.EntryIDs)
 	ds.HistoryPosition_ID(id).Lazy(&c.ID)
@@ -1302,7 +1469,8 @@ type importPreviewBuilder struct {
 	builder[importPreviewBuilder, *importPreviewBuilder, ImportPreview]
 }
 
-func (b *importPreviewBuilder) lazy(ds *Fetch, id int) *ImportPreview {
+func (b *importPreviewBuilder) lazy(ds *Fetch, idI any) *ImportPreview {
+	id := idI.(int)
 	c := ImportPreview{}
 	ds.ImportPreview_Created(id).Lazy(&c.Created)
 	ds.ImportPreview_ID(id).Lazy(&c.ID)
@@ -1326,16 +1494,6 @@ func (r *Fetch) ImportPreview(ids ...int) *importPreviewBuilder {
 	}
 }
 
-type ListOfSpeakersContentObjectUnion interface {
-	isListOfSpeakersContentObjectUnion()
-}
-
-func (*Motion) isListOfSpeakersContentObjectUnion()           {}
-func (*MotionBlock) isListOfSpeakersContentObjectUnion()      {}
-func (*Assignment) isListOfSpeakersContentObjectUnion()       {}
-func (*Topic) isListOfSpeakersContentObjectUnion()            {}
-func (*MeetingMediafile) isListOfSpeakersContentObjectUnion() {}
-
 // ListOfSpeakers has all fields from list_of_speakers.
 type ListOfSpeakers struct {
 	Closed                           bool
@@ -1358,7 +1516,8 @@ type listOfSpeakersBuilder struct {
 	builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]
 }
 
-func (b *listOfSpeakersBuilder) lazy(ds *Fetch, id int) *ListOfSpeakers {
+func (b *listOfSpeakersBuilder) lazy(ds *Fetch, idI any) *ListOfSpeakers {
+	id := idI.(int)
 	c := ListOfSpeakers{}
 	ds.ListOfSpeakers_Closed(id).Lazy(&c.Closed)
 	ds.ListOfSpeakers_ContentObjectID(id).Lazy(&c.ContentObjectID)
@@ -1377,7 +1536,108 @@ func (b *listOfSpeakersBuilder) Preload(rel builderWrapperI) *listOfSpeakersBuil
 	return b
 }
 
-// TODO: func (b *listOfSpeakersBuilder) ContentObject()
+func (b *listOfSpeakersBuilder) ContentObject() *listOfSpeakersContentObjectUnionBuilder {
+	return &listOfSpeakersContentObjectUnionBuilder{
+		builder: builder[listOfSpeakersContentObjectUnionBuilder, *listOfSpeakersContentObjectUnionBuilder, ListOfSpeakersContentObjectUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ContentObjectID",
+			relField: "ContentObject",
+		},
+	}
+}
+
+type ListOfSpeakersContentObjectUnion interface {
+	isListOfSpeakersContentObjectUnion()
+}
+
+func (*Motion) isListOfSpeakersContentObjectUnion()           {}
+func (*MotionBlock) isListOfSpeakersContentObjectUnion()      {}
+func (*Assignment) isListOfSpeakersContentObjectUnion()       {}
+func (*Topic) isListOfSpeakersContentObjectUnion()            {}
+func (*MeetingMediafile) isListOfSpeakersContentObjectUnion() {}
+
+type listOfSpeakersContentObjectUnionBuilder struct {
+	builder[listOfSpeakersContentObjectUnionBuilder, *listOfSpeakersContentObjectUnionBuilder, ListOfSpeakersContentObjectUnion]
+}
+
+func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListOfSpeakersContentObjectUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "motion":
+
+		builder := &motionBuilder{
+			builder: builder[motionBuilder, *motionBuilder, Motion]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+
+	case "motion_block":
+
+		builder := &motionBlockBuilder{
+			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+
+	case "assignment":
+
+		builder := &assignmentBuilder{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+
+	case "topic":
+
+		builder := &topicBuilder{
+			builder: builder[topicBuilder, *topicBuilder, Topic]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+
+	case "meeting_mediafile":
+
+		builder := &meetingMediafileBuilder{
+			builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *listOfSpeakersContentObjectUnionBuilder) Preload(rel builderWrapperI) *listOfSpeakersContentObjectUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *listOfSpeakersBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
@@ -1435,13 +1695,6 @@ func (r *Fetch) ListOfSpeakers(ids ...int) *listOfSpeakersBuilder {
 	}
 }
 
-type MediafileOwnerUnion interface {
-	isMediafileOwnerUnion()
-}
-
-func (*Meeting) isMediafileOwnerUnion()      {}
-func (*Organization) isMediafileOwnerUnion() {}
-
 // Mediafile has all fields from mediafile.
 type Mediafile struct {
 	ChildIDs                            []int
@@ -1469,7 +1722,8 @@ type mediafileBuilder struct {
 	builder[mediafileBuilder, *mediafileBuilder, Mediafile]
 }
 
-func (b *mediafileBuilder) lazy(ds *Fetch, id int) *Mediafile {
+func (b *mediafileBuilder) lazy(ds *Fetch, idI any) *Mediafile {
+	id := idI.(int)
 	c := Mediafile{}
 	ds.Mediafile_ChildIDs(id).Lazy(&c.ChildIDs)
 	ds.Mediafile_CreateTimestamp(id).Lazy(&c.CreateTimestamp)
@@ -1517,7 +1771,75 @@ func (b *mediafileBuilder) MeetingMediafileList() *meetingMediafileBuilder {
 	}
 }
 
-// TODO: func (b *mediafileBuilder) Owner()
+func (b *mediafileBuilder) Owner() *mediafileOwnerUnionBuilder {
+	return &mediafileOwnerUnionBuilder{
+		builder: builder[mediafileOwnerUnionBuilder, *mediafileOwnerUnionBuilder, MediafileOwnerUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "OwnerID",
+			relField: "Owner",
+		},
+	}
+}
+
+type MediafileOwnerUnion interface {
+	isMediafileOwnerUnion()
+}
+
+func (*Meeting) isMediafileOwnerUnion()      {}
+func (*Organization) isMediafileOwnerUnion() {}
+
+type mediafileOwnerUnionBuilder struct {
+	builder[mediafileOwnerUnionBuilder, *mediafileOwnerUnionBuilder, MediafileOwnerUnion]
+}
+
+func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) *MediafileOwnerUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "meeting":
+
+		builder := &meetingBuilder{
+			builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*MediafileOwnerUnion)(unsafe.Pointer(result))
+
+	case "organization":
+
+		builder := &organizationBuilder{
+			builder: builder[organizationBuilder, *organizationBuilder, Organization]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*MediafileOwnerUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *mediafileOwnerUnionBuilder) Preload(rel builderWrapperI) *mediafileOwnerUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *mediafileBuilder) Parent() *mediafileBuilder {
 	return &mediafileBuilder{
@@ -1885,7 +2207,8 @@ type meetingBuilder struct {
 	builder[meetingBuilder, *meetingBuilder, Meeting]
 }
 
-func (b *meetingBuilder) lazy(ds *Fetch, id int) *Meeting {
+func (b *meetingBuilder) lazy(ds *Fetch, idI any) *Meeting {
+	id := idI.(int)
 	c := Meeting{}
 	ds.Meeting_AdminGroupID(id).Lazy(&c.AdminGroupID)
 	ds.Meeting_AgendaEnableNumbering(id).Lazy(&c.AgendaEnableNumbering)
@@ -3214,7 +3537,8 @@ type meetingMediafileBuilder struct {
 	builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]
 }
 
-func (b *meetingMediafileBuilder) lazy(ds *Fetch, id int) *MeetingMediafile {
+func (b *meetingMediafileBuilder) lazy(ds *Fetch, idI any) *MeetingMediafile {
+	id := idI.(int)
 	c := MeetingMediafile{}
 	ds.MeetingMediafile_AccessGroupIDs(id).Lazy(&c.AccessGroupIDs)
 	ds.MeetingMediafile_AttachmentIDs(id).Lazy(&c.AttachmentIDs)
@@ -3553,7 +3877,8 @@ type meetingUserBuilder struct {
 	builder[meetingUserBuilder, *meetingUserBuilder, MeetingUser]
 }
 
-func (b *meetingUserBuilder) lazy(ds *Fetch, id int) *MeetingUser {
+func (b *meetingUserBuilder) lazy(ds *Fetch, idI any) *MeetingUser {
+	id := idI.(int)
 	c := MeetingUser{}
 	ds.MeetingUser_AboutMe(id).Lazy(&c.AboutMe)
 	ds.MeetingUser_ActingBallotIDs(id).Lazy(&c.ActingBallotIDs)
@@ -3903,7 +4228,8 @@ type motionBuilder struct {
 	builder[motionBuilder, *motionBuilder, Motion]
 }
 
-func (b *motionBuilder) lazy(ds *Fetch, id int) *Motion {
+func (b *motionBuilder) lazy(ds *Fetch, idI any) *Motion {
+	id := idI.(int)
 	c := Motion{}
 	ds.Motion_AdditionalSubmitter(id).Lazy(&c.AdditionalSubmitter)
 	ds.Motion_AgendaItemID(id).Lazy(&c.AgendaItemID)
@@ -4360,7 +4686,8 @@ type motionBlockBuilder struct {
 	builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]
 }
 
-func (b *motionBlockBuilder) lazy(ds *Fetch, id int) *MotionBlock {
+func (b *motionBlockBuilder) lazy(ds *Fetch, idI any) *MotionBlock {
+	id := idI.(int)
 	c := MotionBlock{}
 	ds.MotionBlock_AgendaItemID(id).Lazy(&c.AgendaItemID)
 	ds.MotionBlock_ID(id).Lazy(&c.ID)
@@ -4467,7 +4794,8 @@ type motionCategoryBuilder struct {
 	builder[motionCategoryBuilder, *motionCategoryBuilder, MotionCategory]
 }
 
-func (b *motionCategoryBuilder) lazy(ds *Fetch, id int) *MotionCategory {
+func (b *motionCategoryBuilder) lazy(ds *Fetch, idI any) *MotionCategory {
+	id := idI.(int)
 	c := MotionCategory{}
 	ds.MotionCategory_ChildIDs(id).Lazy(&c.ChildIDs)
 	ds.MotionCategory_ID(id).Lazy(&c.ID)
@@ -4563,7 +4891,8 @@ type motionChangeRecommendationBuilder struct {
 	builder[motionChangeRecommendationBuilder, *motionChangeRecommendationBuilder, MotionChangeRecommendation]
 }
 
-func (b *motionChangeRecommendationBuilder) lazy(ds *Fetch, id int) *MotionChangeRecommendation {
+func (b *motionChangeRecommendationBuilder) lazy(ds *Fetch, idI any) *MotionChangeRecommendation {
+	id := idI.(int)
 	c := MotionChangeRecommendation{}
 	ds.MotionChangeRecommendation_CreationTime(id).Lazy(&c.CreationTime)
 	ds.MotionChangeRecommendation_ID(id).Lazy(&c.ID)
@@ -4631,7 +4960,8 @@ type motionCommentBuilder struct {
 	builder[motionCommentBuilder, *motionCommentBuilder, MotionComment]
 }
 
-func (b *motionCommentBuilder) lazy(ds *Fetch, id int) *MotionComment {
+func (b *motionCommentBuilder) lazy(ds *Fetch, idI any) *MotionComment {
+	id := idI.(int)
 	c := MotionComment{}
 	ds.MotionComment_Comment(id).Lazy(&c.Comment)
 	ds.MotionComment_ID(id).Lazy(&c.ID)
@@ -4709,7 +5039,8 @@ type motionCommentSectionBuilder struct {
 	builder[motionCommentSectionBuilder, *motionCommentSectionBuilder, MotionCommentSection]
 }
 
-func (b *motionCommentSectionBuilder) lazy(ds *Fetch, id int) *MotionCommentSection {
+func (b *motionCommentSectionBuilder) lazy(ds *Fetch, idI any) *MotionCommentSection {
+	id := idI.(int)
 	c := MotionCommentSection{}
 	ds.MotionCommentSection_CommentIDs(id).Lazy(&c.CommentIDs)
 	ds.MotionCommentSection_ID(id).Lazy(&c.ID)
@@ -4800,7 +5131,8 @@ type motionEditorBuilder struct {
 	builder[motionEditorBuilder, *motionEditorBuilder, MotionEditor]
 }
 
-func (b *motionEditorBuilder) lazy(ds *Fetch, id int) *MotionEditor {
+func (b *motionEditorBuilder) lazy(ds *Fetch, idI any) *MotionEditor {
+	id := idI.(int)
 	c := MotionEditor{}
 	ds.MotionEditor_ID(id).Lazy(&c.ID)
 	ds.MotionEditor_MeetingID(id).Lazy(&c.MeetingID)
@@ -4901,7 +5233,8 @@ type motionStateBuilder struct {
 	builder[motionStateBuilder, *motionStateBuilder, MotionState]
 }
 
-func (b *motionStateBuilder) lazy(ds *Fetch, id int) *MotionState {
+func (b *motionStateBuilder) lazy(ds *Fetch, idI any) *MotionState {
+	id := idI.(int)
 	c := MotionState{}
 	ds.MotionState_AllowAmendmentForwarding(id).Lazy(&c.AllowAmendmentForwarding)
 	ds.MotionState_AllowCreatePoll(id).Lazy(&c.AllowCreatePoll)
@@ -5067,7 +5400,8 @@ type motionSubmitterBuilder struct {
 	builder[motionSubmitterBuilder, *motionSubmitterBuilder, MotionSubmitter]
 }
 
-func (b *motionSubmitterBuilder) lazy(ds *Fetch, id int) *MotionSubmitter {
+func (b *motionSubmitterBuilder) lazy(ds *Fetch, idI any) *MotionSubmitter {
+	id := idI.(int)
 	c := MotionSubmitter{}
 	ds.MotionSubmitter_ID(id).Lazy(&c.ID)
 	ds.MotionSubmitter_MeetingID(id).Lazy(&c.MeetingID)
@@ -5139,7 +5473,8 @@ type motionSupporterBuilder struct {
 	builder[motionSupporterBuilder, *motionSupporterBuilder, MotionSupporter]
 }
 
-func (b *motionSupporterBuilder) lazy(ds *Fetch, id int) *MotionSupporter {
+func (b *motionSupporterBuilder) lazy(ds *Fetch, idI any) *MotionSupporter {
+	id := idI.(int)
 	c := MotionSupporter{}
 	ds.MotionSupporter_ID(id).Lazy(&c.ID)
 	ds.MotionSupporter_MeetingID(id).Lazy(&c.MeetingID)
@@ -5216,7 +5551,8 @@ type motionWorkflowBuilder struct {
 	builder[motionWorkflowBuilder, *motionWorkflowBuilder, MotionWorkflow]
 }
 
-func (b *motionWorkflowBuilder) lazy(ds *Fetch, id int) *MotionWorkflow {
+func (b *motionWorkflowBuilder) lazy(ds *Fetch, idI any) *MotionWorkflow {
+	id := idI.(int)
 	c := MotionWorkflow{}
 	ds.MotionWorkflow_DefaultAmendmentWorkflowMeetingID(id).Lazy(&c.DefaultAmendmentWorkflowMeetingID)
 	ds.MotionWorkflow_DefaultWorkflowMeetingID(id).Lazy(&c.DefaultWorkflowMeetingID)
@@ -5315,7 +5651,8 @@ type motionWorkingGroupSpeakerBuilder struct {
 	builder[motionWorkingGroupSpeakerBuilder, *motionWorkingGroupSpeakerBuilder, MotionWorkingGroupSpeaker]
 }
 
-func (b *motionWorkingGroupSpeakerBuilder) lazy(ds *Fetch, id int) *MotionWorkingGroupSpeaker {
+func (b *motionWorkingGroupSpeakerBuilder) lazy(ds *Fetch, idI any) *MotionWorkingGroupSpeaker {
+	id := idI.(int)
 	c := MotionWorkingGroupSpeaker{}
 	ds.MotionWorkingGroupSpeaker_ID(id).Lazy(&c.ID)
 	ds.MotionWorkingGroupSpeaker_MeetingID(id).Lazy(&c.MeetingID)
@@ -5431,7 +5768,8 @@ type organizationBuilder struct {
 	builder[organizationBuilder, *organizationBuilder, Organization]
 }
 
-func (b *organizationBuilder) lazy(ds *Fetch, id int) *Organization {
+func (b *organizationBuilder) lazy(ds *Fetch, idI any) *Organization {
+	id := idI.(int)
 	c := Organization{}
 	ds.Organization_ActiveMeetingIDs(id).Lazy(&c.ActiveMeetingIDs)
 	ds.Organization_ArchivedMeetingIDs(id).Lazy(&c.ArchivedMeetingIDs)
@@ -5635,7 +5973,8 @@ type organizationTagBuilder struct {
 	builder[organizationTagBuilder, *organizationTagBuilder, OrganizationTag]
 }
 
-func (b *organizationTagBuilder) lazy(ds *Fetch, id int) *OrganizationTag {
+func (b *organizationTagBuilder) lazy(ds *Fetch, idI any) *OrganizationTag {
+	id := idI.(int)
 	c := OrganizationTag{}
 	ds.OrganizationTag_Color(id).Lazy(&c.Color)
 	ds.OrganizationTag_ID(id).Lazy(&c.ID)
@@ -5670,12 +6009,6 @@ func (r *Fetch) OrganizationTag(ids ...int) *organizationTagBuilder {
 	}
 }
 
-type PersonalNoteContentObjectUnion interface {
-	isPersonalNoteContentObjectUnion()
-}
-
-func (*Motion) isPersonalNoteContentObjectUnion() {}
-
 // PersonalNote has all fields from personal_note.
 type PersonalNote struct {
 	ContentObjectID string
@@ -5693,7 +6026,8 @@ type personalNoteBuilder struct {
 	builder[personalNoteBuilder, *personalNoteBuilder, PersonalNote]
 }
 
-func (b *personalNoteBuilder) lazy(ds *Fetch, id int) *PersonalNote {
+func (b *personalNoteBuilder) lazy(ds *Fetch, idI any) *PersonalNote {
+	id := idI.(int)
 	c := PersonalNote{}
 	ds.PersonalNote_ContentObjectID(id).Lazy(&c.ContentObjectID)
 	ds.PersonalNote_ID(id).Lazy(&c.ID)
@@ -5709,7 +6043,64 @@ func (b *personalNoteBuilder) Preload(rel builderWrapperI) *personalNoteBuilder 
 	return b
 }
 
-// TODO: func (b *personalNoteBuilder) ContentObject()
+func (b *personalNoteBuilder) ContentObject() *personalNoteContentObjectUnionBuilder {
+	return &personalNoteContentObjectUnionBuilder{
+		builder: builder[personalNoteContentObjectUnionBuilder, *personalNoteContentObjectUnionBuilder, PersonalNoteContentObjectUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ContentObjectID",
+			relField: "ContentObject",
+		},
+	}
+}
+
+type PersonalNoteContentObjectUnion interface {
+	isPersonalNoteContentObjectUnion()
+}
+
+func (*Motion) isPersonalNoteContentObjectUnion() {}
+
+type personalNoteContentObjectUnionBuilder struct {
+	builder[personalNoteContentObjectUnionBuilder, *personalNoteContentObjectUnionBuilder, PersonalNoteContentObjectUnion]
+}
+
+func (b *personalNoteContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PersonalNoteContentObjectUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "motion":
+
+		builder := &motionBuilder{
+			builder: builder[motionBuilder, *motionBuilder, Motion]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PersonalNoteContentObjectUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *personalNoteContentObjectUnionBuilder) Preload(rel builderWrapperI) *personalNoteContentObjectUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *personalNoteBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
@@ -5757,7 +6148,8 @@ type pointOfOrderCategoryBuilder struct {
 	builder[pointOfOrderCategoryBuilder, *pointOfOrderCategoryBuilder, PointOfOrderCategory]
 }
 
-func (b *pointOfOrderCategoryBuilder) lazy(ds *Fetch, id int) *PointOfOrderCategory {
+func (b *pointOfOrderCategoryBuilder) lazy(ds *Fetch, idI any) *PointOfOrderCategory {
+	id := idI.(int)
 	c := PointOfOrderCategory{}
 	ds.PointOfOrderCategory_ID(id).Lazy(&c.ID)
 	ds.PointOfOrderCategory_MeetingID(id).Lazy(&c.MeetingID)
@@ -5804,24 +6196,6 @@ func (r *Fetch) PointOfOrderCategory(ids ...int) *pointOfOrderCategoryBuilder {
 	}
 }
 
-type PollConfigUnion interface {
-	isPollConfigUnion()
-}
-
-func (*PollConfigApproval) isPollConfigUnion()       {}
-func (*PollConfigSelection) isPollConfigUnion()      {}
-func (*PollConfigRatingScore) isPollConfigUnion()    {}
-func (*PollConfigRatingApproval) isPollConfigUnion() {}
-func (*PollConfigStvScottish) isPollConfigUnion()    {}
-
-type PollContentObjectUnion interface {
-	isPollContentObjectUnion()
-}
-
-func (*Motion) isPollContentObjectUnion()     {}
-func (*Assignment) isPollContentObjectUnion() {}
-func (*Topic) isPollContentObjectUnion()      {}
-
 // Poll has all fields from poll.
 type Poll struct {
 	AllowInvalid      bool
@@ -5857,7 +6231,8 @@ type pollBuilder struct {
 	builder[pollBuilder, *pollBuilder, Poll]
 }
 
-func (b *pollBuilder) lazy(ds *Fetch, id int) *Poll {
+func (b *pollBuilder) lazy(ds *Fetch, idI any) *Poll {
+	id := idI.(int)
 	c := Poll{}
 	ds.Poll_AllowInvalid(id).Lazy(&c.AllowInvalid)
 	ds.Poll_AllowVoteSplit(id).Lazy(&c.AllowVoteSplit)
@@ -5898,9 +6273,189 @@ func (b *pollBuilder) BallotList() *pollBallotBuilder {
 	}
 }
 
-// TODO: func (b *pollBuilder) Config()
+func (b *pollBuilder) Config() *pollConfigUnionBuilder {
+	return &pollConfigUnionBuilder{
+		builder: builder[pollConfigUnionBuilder, *pollConfigUnionBuilder, PollConfigUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ConfigID",
+			relField: "Config",
+		},
+	}
+}
 
-// TODO: func (b *pollBuilder) ContentObject()
+type PollConfigUnion interface {
+	isPollConfigUnion()
+}
+
+func (*PollConfigApproval) isPollConfigUnion()       {}
+func (*PollConfigSelection) isPollConfigUnion()      {}
+func (*PollConfigRatingScore) isPollConfigUnion()    {}
+func (*PollConfigRatingApproval) isPollConfigUnion() {}
+func (*PollConfigStvScottish) isPollConfigUnion()    {}
+
+type pollConfigUnionBuilder struct {
+	builder[pollConfigUnionBuilder, *pollConfigUnionBuilder, PollConfigUnion]
+}
+
+func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "poll_config_approval":
+
+		builder := &pollConfigApprovalBuilder{
+			builder: builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollConfigUnion)(unsafe.Pointer(result))
+
+	case "poll_config_selection":
+
+		builder := &pollConfigSelectionBuilder{
+			builder: builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollConfigUnion)(unsafe.Pointer(result))
+
+	case "poll_config_rating_score":
+
+		builder := &pollConfigRatingScoreBuilder{
+			builder: builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollConfigUnion)(unsafe.Pointer(result))
+
+	case "poll_config_rating_approval":
+
+		builder := &pollConfigRatingApprovalBuilder{
+			builder: builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollConfigUnion)(unsafe.Pointer(result))
+
+	case "poll_config_stv_scottish":
+
+		builder := &pollConfigStvScottishBuilder{
+			builder: builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollConfigUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *pollConfigUnionBuilder) Preload(rel builderWrapperI) *pollConfigUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
+
+func (b *pollBuilder) ContentObject() *pollContentObjectUnionBuilder {
+	return &pollContentObjectUnionBuilder{
+		builder: builder[pollContentObjectUnionBuilder, *pollContentObjectUnionBuilder, PollContentObjectUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ContentObjectID",
+			relField: "ContentObject",
+		},
+	}
+}
+
+type PollContentObjectUnion interface {
+	isPollContentObjectUnion()
+}
+
+func (*Motion) isPollContentObjectUnion()     {}
+func (*Assignment) isPollContentObjectUnion() {}
+func (*Topic) isPollContentObjectUnion()      {}
+
+type pollContentObjectUnionBuilder struct {
+	builder[pollContentObjectUnionBuilder, *pollContentObjectUnionBuilder, PollContentObjectUnion]
+}
+
+func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObjectUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "motion":
+
+		builder := &motionBuilder{
+			builder: builder[motionBuilder, *motionBuilder, Motion]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollContentObjectUnion)(unsafe.Pointer(result))
+
+	case "assignment":
+
+		builder := &assignmentBuilder{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollContentObjectUnion)(unsafe.Pointer(result))
+
+	case "topic":
+
+		builder := &topicBuilder{
+			builder: builder[topicBuilder, *topicBuilder, Topic]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*PollContentObjectUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *pollContentObjectUnionBuilder) Preload(rel builderWrapperI) *pollContentObjectUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *pollBuilder) EntitledGroupList() *groupBuilder {
 	return &groupBuilder{
@@ -5988,7 +6543,8 @@ type pollBallotBuilder struct {
 	builder[pollBallotBuilder, *pollBallotBuilder, PollBallot]
 }
 
-func (b *pollBallotBuilder) lazy(ds *Fetch, id int) *PollBallot {
+func (b *pollBallotBuilder) lazy(ds *Fetch, idI any) *PollBallot {
+	id := idI.(int)
 	c := PollBallot{}
 	ds.PollBallot_ActingMeetingUserID(id).Lazy(&c.ActingMeetingUserID)
 	ds.PollBallot_ID(id).Lazy(&c.ID)
@@ -6060,7 +6616,8 @@ type pollConfigApprovalBuilder struct {
 	builder[pollConfigApprovalBuilder, *pollConfigApprovalBuilder, PollConfigApproval]
 }
 
-func (b *pollConfigApprovalBuilder) lazy(ds *Fetch, id int) *PollConfigApproval {
+func (b *pollConfigApprovalBuilder) lazy(ds *Fetch, idI any) *PollConfigApproval {
+	id := idI.(int)
 	c := PollConfigApproval{}
 	ds.PollConfigApproval_AllowAbstain(id).Lazy(&c.AllowAbstain)
 	ds.PollConfigApproval_ID(id).Lazy(&c.ID)
@@ -6109,7 +6666,8 @@ type pollConfigRatingApprovalBuilder struct {
 	builder[pollConfigRatingApprovalBuilder, *pollConfigRatingApprovalBuilder, PollConfigRatingApproval]
 }
 
-func (b *pollConfigRatingApprovalBuilder) lazy(ds *Fetch, id int) *PollConfigRatingApproval {
+func (b *pollConfigRatingApprovalBuilder) lazy(ds *Fetch, idI any) *PollConfigRatingApproval {
+	id := idI.(int)
 	c := PollConfigRatingApproval{}
 	ds.PollConfigRatingApproval_AllowAbstain(id).Lazy(&c.AllowAbstain)
 	ds.PollConfigRatingApproval_ID(id).Lazy(&c.ID)
@@ -6162,7 +6720,8 @@ type pollConfigRatingScoreBuilder struct {
 	builder[pollConfigRatingScoreBuilder, *pollConfigRatingScoreBuilder, PollConfigRatingScore]
 }
 
-func (b *pollConfigRatingScoreBuilder) lazy(ds *Fetch, id int) *PollConfigRatingScore {
+func (b *pollConfigRatingScoreBuilder) lazy(ds *Fetch, idI any) *PollConfigRatingScore {
+	id := idI.(int)
 	c := PollConfigRatingScore{}
 	ds.PollConfigRatingScore_ID(id).Lazy(&c.ID)
 	ds.PollConfigRatingScore_MaxOptionsAmount(id).Lazy(&c.MaxOptionsAmount)
@@ -6217,7 +6776,8 @@ type pollConfigSelectionBuilder struct {
 	builder[pollConfigSelectionBuilder, *pollConfigSelectionBuilder, PollConfigSelection]
 }
 
-func (b *pollConfigSelectionBuilder) lazy(ds *Fetch, id int) *PollConfigSelection {
+func (b *pollConfigSelectionBuilder) lazy(ds *Fetch, idI any) *PollConfigSelection {
+	id := idI.(int)
 	c := PollConfigSelection{}
 	ds.PollConfigSelection_AllowNota(id).Lazy(&c.AllowNota)
 	ds.PollConfigSelection_DisplayChart(id).Lazy(&c.DisplayChart)
@@ -6267,7 +6827,8 @@ type pollConfigStvScottishBuilder struct {
 	builder[pollConfigStvScottishBuilder, *pollConfigStvScottishBuilder, PollConfigStvScottish]
 }
 
-func (b *pollConfigStvScottishBuilder) lazy(ds *Fetch, id int) *PollConfigStvScottish {
+func (b *pollConfigStvScottishBuilder) lazy(ds *Fetch, idI any) *PollConfigStvScottish {
+	id := idI.(int)
 	c := PollConfigStvScottish{}
 	ds.PollConfigStvScottish_ID(id).Lazy(&c.ID)
 	ds.PollConfigStvScottish_PollID(id).Lazy(&c.PollID)
@@ -6315,7 +6876,8 @@ type pollOptionBuilder struct {
 	builder[pollOptionBuilder, *pollOptionBuilder, PollOption]
 }
 
-func (b *pollOptionBuilder) lazy(ds *Fetch, id int) *PollOption {
+func (b *pollOptionBuilder) lazy(ds *Fetch, idI any) *PollOption {
+	id := idI.(int)
 	c := PollOption{}
 	ds.PollOption_ID(id).Lazy(&c.ID)
 	ds.PollOption_MeetingUserID(id).Lazy(&c.MeetingUserID)
@@ -6361,22 +6923,6 @@ func (r *Fetch) PollOption(ids ...int) *pollOptionBuilder {
 	}
 }
 
-type ProjectionContentObjectUnion interface {
-	isProjectionContentObjectUnion()
-}
-
-func (*Meeting) isProjectionContentObjectUnion()            {}
-func (*Motion) isProjectionContentObjectUnion()             {}
-func (*MeetingMediafile) isProjectionContentObjectUnion()   {}
-func (*ListOfSpeakers) isProjectionContentObjectUnion()     {}
-func (*MotionBlock) isProjectionContentObjectUnion()        {}
-func (*Assignment) isProjectionContentObjectUnion()         {}
-func (*AgendaItem) isProjectionContentObjectUnion()         {}
-func (*Topic) isProjectionContentObjectUnion()              {}
-func (*Poll) isProjectionContentObjectUnion()               {}
-func (*ProjectorMessage) isProjectionContentObjectUnion()   {}
-func (*ProjectorCountdown) isProjectionContentObjectUnion() {}
-
 // Projection has all fields from projection.
 type Projection struct {
 	ContentObjectID    string
@@ -6400,7 +6946,8 @@ type projectionBuilder struct {
 	builder[projectionBuilder, *projectionBuilder, Projection]
 }
 
-func (b *projectionBuilder) lazy(ds *Fetch, id int) *Projection {
+func (b *projectionBuilder) lazy(ds *Fetch, idI any) *Projection {
+	id := idI.(int)
 	c := Projection{}
 	ds.Projection_ContentObjectID(id).Lazy(&c.ContentObjectID)
 	ds.Projection_CurrentProjectorID(id).Lazy(&c.CurrentProjectorID)
@@ -6420,7 +6967,174 @@ func (b *projectionBuilder) Preload(rel builderWrapperI) *projectionBuilder {
 	return b
 }
 
-// TODO: func (b *projectionBuilder) ContentObject()
+func (b *projectionBuilder) ContentObject() *projectionContentObjectUnionBuilder {
+	return &projectionContentObjectUnionBuilder{
+		builder: builder[projectionContentObjectUnionBuilder, *projectionContentObjectUnionBuilder, ProjectionContentObjectUnion]{
+			fetch:    b.fetch,
+			parent:   b,
+			idField:  "ContentObjectID",
+			relField: "ContentObject",
+		},
+	}
+}
+
+type ProjectionContentObjectUnion interface {
+	isProjectionContentObjectUnion()
+}
+
+func (*Meeting) isProjectionContentObjectUnion()            {}
+func (*Motion) isProjectionContentObjectUnion()             {}
+func (*MeetingMediafile) isProjectionContentObjectUnion()   {}
+func (*ListOfSpeakers) isProjectionContentObjectUnion()     {}
+func (*MotionBlock) isProjectionContentObjectUnion()        {}
+func (*Assignment) isProjectionContentObjectUnion()         {}
+func (*AgendaItem) isProjectionContentObjectUnion()         {}
+func (*Topic) isProjectionContentObjectUnion()              {}
+func (*Poll) isProjectionContentObjectUnion()               {}
+func (*ProjectorMessage) isProjectionContentObjectUnion()   {}
+func (*ProjectorCountdown) isProjectionContentObjectUnion() {}
+
+type projectionContentObjectUnionBuilder struct {
+	builder[projectionContentObjectUnionBuilder, *projectionContentObjectUnionBuilder, ProjectionContentObjectUnion]
+}
+
+func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ProjectionContentObjectUnion {
+	fqid, ok := id.(string)
+	if !ok {
+		return nil
+	}
+
+	collection, idStr, ok := strings.Cut(fqid, "/")
+	if !ok {
+		return nil
+	}
+
+	intId, err := strconv.Atoi(idStr)
+	if err != nil {
+		return nil
+	}
+
+	switch collection {
+
+	case "meeting":
+
+		builder := &meetingBuilder{
+			builder: builder[meetingBuilder, *meetingBuilder, Meeting]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "motion":
+
+		builder := &motionBuilder{
+			builder: builder[motionBuilder, *motionBuilder, Motion]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "meeting_mediafile":
+
+		builder := &meetingMediafileBuilder{
+			builder: builder[meetingMediafileBuilder, *meetingMediafileBuilder, MeetingMediafile]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "list_of_speakers":
+
+		builder := &listOfSpeakersBuilder{
+			builder: builder[listOfSpeakersBuilder, *listOfSpeakersBuilder, ListOfSpeakers]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "motion_block":
+
+		builder := &motionBlockBuilder{
+			builder: builder[motionBlockBuilder, *motionBlockBuilder, MotionBlock]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "assignment":
+
+		builder := &assignmentBuilder{
+			builder: builder[assignmentBuilder, *assignmentBuilder, Assignment]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "agenda_item":
+
+		builder := &agendaItemBuilder{
+			builder: builder[agendaItemBuilder, *agendaItemBuilder, AgendaItem]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "topic":
+
+		builder := &topicBuilder{
+			builder: builder[topicBuilder, *topicBuilder, Topic]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "poll":
+
+		builder := &pollBuilder{
+			builder: builder[pollBuilder, *pollBuilder, Poll]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "projector_message":
+
+		builder := &projectorMessageBuilder{
+			builder: builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	case "projector_countdown":
+
+		builder := &projectorCountdownBuilder{
+			builder: builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]{
+				fetch: ds,
+			},
+		}
+		result := builder.lazy(ds, intId)
+		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+
+	}
+
+	return nil
+}
+
+func (b *projectionContentObjectUnionBuilder) Preload(rel builderWrapperI) *projectionContentObjectUnionBuilder {
+	b.builder.Preload(rel)
+	return b
+}
 
 func (b *projectionBuilder) CurrentProjector() *projectorBuilder {
 	return &projectorBuilder{
@@ -6543,7 +7257,8 @@ type projectorBuilder struct {
 	builder[projectorBuilder, *projectorBuilder, Projector]
 }
 
-func (b *projectorBuilder) lazy(ds *Fetch, id int) *Projector {
+func (b *projectorBuilder) lazy(ds *Fetch, idI any) *Projector {
+	id := idI.(int)
 	c := Projector{}
 	ds.Projector_AspectRatioDenominator(id).Lazy(&c.AspectRatioDenominator)
 	ds.Projector_AspectRatioNumerator(id).Lazy(&c.AspectRatioNumerator)
@@ -6837,7 +7552,8 @@ type projectorCountdownBuilder struct {
 	builder[projectorCountdownBuilder, *projectorCountdownBuilder, ProjectorCountdown]
 }
 
-func (b *projectorCountdownBuilder) lazy(ds *Fetch, id int) *ProjectorCountdown {
+func (b *projectorCountdownBuilder) lazy(ds *Fetch, idI any) *ProjectorCountdown {
+	id := idI.(int)
 	c := ProjectorCountdown{}
 	ds.ProjectorCountdown_CountdownTime(id).Lazy(&c.CountdownTime)
 	ds.ProjectorCountdown_DefaultTime(id).Lazy(&c.DefaultTime)
@@ -6925,7 +7641,8 @@ type projectorMessageBuilder struct {
 	builder[projectorMessageBuilder, *projectorMessageBuilder, ProjectorMessage]
 }
 
-func (b *projectorMessageBuilder) lazy(ds *Fetch, id int) *ProjectorMessage {
+func (b *projectorMessageBuilder) lazy(ds *Fetch, idI any) *ProjectorMessage {
+	id := idI.(int)
 	c := ProjectorMessage{}
 	ds.ProjectorMessage_ID(id).Lazy(&c.ID)
 	ds.ProjectorMessage_MeetingID(id).Lazy(&c.MeetingID)
@@ -7000,7 +7717,8 @@ type speakerBuilder struct {
 	builder[speakerBuilder, *speakerBuilder, Speaker]
 }
 
-func (b *speakerBuilder) lazy(ds *Fetch, id int) *Speaker {
+func (b *speakerBuilder) lazy(ds *Fetch, idI any) *Speaker {
+	id := idI.(int)
 	c := Speaker{}
 	ds.Speaker_Answer(id).Lazy(&c.Answer)
 	ds.Speaker_BeginTime(id).Lazy(&c.BeginTime)
@@ -7108,7 +7826,8 @@ type structureLevelBuilder struct {
 	builder[structureLevelBuilder, *structureLevelBuilder, StructureLevel]
 }
 
-func (b *structureLevelBuilder) lazy(ds *Fetch, id int) *StructureLevel {
+func (b *structureLevelBuilder) lazy(ds *Fetch, idI any) *StructureLevel {
+	id := idI.(int)
 	c := StructureLevel{}
 	ds.StructureLevel_Color(id).Lazy(&c.Color)
 	ds.StructureLevel_DefaultTime(id).Lazy(&c.DefaultTime)
@@ -7190,7 +7909,8 @@ type structureLevelListOfSpeakersBuilder struct {
 	builder[structureLevelListOfSpeakersBuilder, *structureLevelListOfSpeakersBuilder, StructureLevelListOfSpeakers]
 }
 
-func (b *structureLevelListOfSpeakersBuilder) lazy(ds *Fetch, id int) *StructureLevelListOfSpeakers {
+func (b *structureLevelListOfSpeakersBuilder) lazy(ds *Fetch, idI any) *StructureLevelListOfSpeakers {
+	id := idI.(int)
 	c := StructureLevelListOfSpeakers{}
 	ds.StructureLevelListOfSpeakers_AdditionalTime(id).Lazy(&c.AdditionalTime)
 	ds.StructureLevelListOfSpeakers_CurrentStartTime(id).Lazy(&c.CurrentStartTime)
@@ -7276,7 +7996,8 @@ type tagBuilder struct {
 	builder[tagBuilder, *tagBuilder, Tag]
 }
 
-func (b *tagBuilder) lazy(ds *Fetch, id int) *Tag {
+func (b *tagBuilder) lazy(ds *Fetch, idI any) *Tag {
+	id := idI.(int)
 	c := Tag{}
 	ds.Tag_ID(id).Lazy(&c.ID)
 	ds.Tag_MeetingID(id).Lazy(&c.MeetingID)
@@ -7370,7 +8091,8 @@ type themeBuilder struct {
 	builder[themeBuilder, *themeBuilder, Theme]
 }
 
-func (b *themeBuilder) lazy(ds *Fetch, id int) *Theme {
+func (b *themeBuilder) lazy(ds *Fetch, idI any) *Theme {
+	id := idI.(int)
 	c := Theme{}
 	ds.Theme_Abstain(id).Lazy(&c.Abstain)
 	ds.Theme_Accent100(id).Lazy(&c.Accent100)
@@ -7485,7 +8207,8 @@ type topicBuilder struct {
 	builder[topicBuilder, *topicBuilder, Topic]
 }
 
-func (b *topicBuilder) lazy(ds *Fetch, id int) *Topic {
+func (b *topicBuilder) lazy(ds *Fetch, idI any) *Topic {
+	id := idI.(int)
 	c := Topic{}
 	ds.Topic_AgendaItemID(id).Lazy(&c.AgendaItemID)
 	ds.Topic_AttachmentMeetingMediafileIDs(id).Lazy(&c.AttachmentMeetingMediafileIDs)
@@ -7631,7 +8354,8 @@ type userBuilder struct {
 	builder[userBuilder, *userBuilder, User]
 }
 
-func (b *userBuilder) lazy(ds *Fetch, id int) *User {
+func (b *userBuilder) lazy(ds *Fetch, idI any) *User {
+	id := idI.(int)
 	c := User{}
 	ds.User_CanChangeOwnPassword(id).Lazy(&c.CanChangeOwnPassword)
 	ds.User_CommitteeIDs(id).Lazy(&c.CommitteeIDs)

--- a/datastore/dsmodels/models_generated.go
+++ b/datastore/dsmodels/models_generated.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	"github.com/OpenSlides/openslides-go/datastore/dsfetch"
 	"github.com/shopspring/decimal"
@@ -162,6 +161,7 @@ func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaIte
 		return nil
 	}
 
+	var iface AgendaItemContentObjectUnion
 	switch collection {
 
 	case "motion":
@@ -172,7 +172,8 @@ func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaIte
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "motion_block":
 
@@ -182,7 +183,8 @@ func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaIte
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "assignment":
 
@@ -192,7 +194,8 @@ func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaIte
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "topic":
 
@@ -202,7 +205,8 @@ func (b *agendaItemContentObjectUnionBuilder) lazy(ds *Fetch, id any) *AgendaIte
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*AgendaItemContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -1331,6 +1335,7 @@ func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryMod
 		return nil
 	}
 
+	var iface HistoryEntryModelUnion
 	switch collection {
 
 	case "user":
@@ -1341,7 +1346,8 @@ func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryMod
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*HistoryEntryModelUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "motion":
 
@@ -1351,7 +1357,8 @@ func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryMod
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*HistoryEntryModelUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "assignment":
 
@@ -1361,7 +1368,8 @@ func (b *historyEntryModelUnionBuilder) lazy(ds *Fetch, id any) *HistoryEntryMod
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*HistoryEntryModelUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -1577,6 +1585,7 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 		return nil
 	}
 
+	var iface ListOfSpeakersContentObjectUnion
 	switch collection {
 
 	case "motion":
@@ -1587,7 +1596,8 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "motion_block":
 
@@ -1597,7 +1607,8 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "assignment":
 
@@ -1607,7 +1618,8 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "topic":
 
@@ -1617,7 +1629,8 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "meeting_mediafile":
 
@@ -1627,7 +1640,8 @@ func (b *listOfSpeakersContentObjectUnionBuilder) lazy(ds *Fetch, id any) *ListO
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ListOfSpeakersContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -1809,6 +1823,7 @@ func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) *MediafileOwnerUnio
 		return nil
 	}
 
+	var iface MediafileOwnerUnion
 	switch collection {
 
 	case "meeting":
@@ -1819,7 +1834,8 @@ func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) *MediafileOwnerUnio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*MediafileOwnerUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "organization":
 
@@ -1829,7 +1845,8 @@ func (b *mediafileOwnerUnionBuilder) lazy(ds *Fetch, id any) *MediafileOwnerUnio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*MediafileOwnerUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -6080,6 +6097,7 @@ func (b *personalNoteContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Persona
 		return nil
 	}
 
+	var iface PersonalNoteContentObjectUnion
 	switch collection {
 
 	case "motion":
@@ -6090,7 +6108,8 @@ func (b *personalNoteContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Persona
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PersonalNoteContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -6314,6 +6333,7 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 		return nil
 	}
 
+	var iface PollConfigUnion
 	switch collection {
 
 	case "poll_config_approval":
@@ -6324,7 +6344,8 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollConfigUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "poll_config_selection":
 
@@ -6334,7 +6355,8 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollConfigUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "poll_config_rating_score":
 
@@ -6344,7 +6366,8 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollConfigUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "poll_config_rating_approval":
 
@@ -6354,7 +6377,8 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollConfigUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "poll_config_stv_scottish":
 
@@ -6364,7 +6388,8 @@ func (b *pollConfigUnionBuilder) lazy(ds *Fetch, id any) *PollConfigUnion {
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollConfigUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -6415,6 +6440,7 @@ func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObje
 		return nil
 	}
 
+	var iface PollContentObjectUnion
 	switch collection {
 
 	case "motion":
@@ -6425,7 +6451,8 @@ func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObje
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "assignment":
 
@@ -6435,7 +6462,8 @@ func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObje
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "topic":
 
@@ -6445,7 +6473,8 @@ func (b *pollContentObjectUnionBuilder) lazy(ds *Fetch, id any) *PollContentObje
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*PollContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 
@@ -7014,6 +7043,7 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 		return nil
 	}
 
+	var iface ProjectionContentObjectUnion
 	switch collection {
 
 	case "meeting":
@@ -7024,7 +7054,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "motion":
 
@@ -7034,7 +7065,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "meeting_mediafile":
 
@@ -7044,7 +7076,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "list_of_speakers":
 
@@ -7054,7 +7087,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "motion_block":
 
@@ -7064,7 +7098,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "assignment":
 
@@ -7074,7 +7109,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "agenda_item":
 
@@ -7084,7 +7120,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "topic":
 
@@ -7094,7 +7131,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "poll":
 
@@ -7104,7 +7142,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "projector_message":
 
@@ -7114,7 +7153,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	case "projector_countdown":
 
@@ -7124,7 +7164,8 @@ func (b *projectionContentObjectUnionBuilder) lazy(ds *Fetch, id any) *Projectio
 			},
 		}
 		result := builder.lazy(ds, intId)
-		return (*ProjectionContentObjectUnion)(unsafe.Pointer(result))
+		iface = result
+		return &iface
 
 	}
 

--- a/datastore/dsmodels/models_generated.go
+++ b/datastore/dsmodels/models_generated.go
@@ -48,6 +48,15 @@ func (r *Fetch) ActionWorker(ids ...int) *actionWorkerBuilder {
 	}
 }
 
+type AgendaItemContentObjectUnion interface {
+	isAgendaItemContentObjectUnion()
+}
+
+func (*Motion) isAgendaItemContentObjectUnion()      {}
+func (*MotionBlock) isAgendaItemContentObjectUnion() {}
+func (*Assignment) isAgendaItemContentObjectUnion()  {}
+func (*Topic) isAgendaItemContentObjectUnion()       {}
+
 // AgendaItem has all fields from agenda_item.
 type AgendaItem struct {
 	ChildIDs        []int
@@ -67,6 +76,7 @@ type AgendaItem struct {
 	Type            string
 	Weight          int
 	ChildList       []AgendaItem
+	ContentObject   *AgendaItemContentObjectUnion
 	Meeting         *Meeting
 	Parent          *dsfetch.Maybe[AgendaItem]
 	ProjectionList  []Projection
@@ -114,6 +124,8 @@ func (b *agendaItemBuilder) ChildList() *agendaItemBuilder {
 		},
 	}
 }
+
+// TODO: func (b *agendaItemBuilder) ContentObject()
 
 func (b *agendaItemBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
@@ -1141,6 +1153,14 @@ func (r *Fetch) Group(ids ...int) *groupBuilder {
 	}
 }
 
+type HistoryEntryModelUnion interface {
+	isHistoryEntryModelUnion()
+}
+
+func (*User) isHistoryEntryModelUnion()       {}
+func (*Motion) isHistoryEntryModelUnion()     {}
+func (*Assignment) isHistoryEntryModelUnion() {}
+
 // HistoryEntry has all fields from history_entry.
 type HistoryEntry struct {
 	Entries         []string
@@ -1150,6 +1170,7 @@ type HistoryEntry struct {
 	OriginalModelID string
 	PositionID      int
 	Meeting         *dsfetch.Maybe[Meeting]
+	Model           *dsfetch.Maybe[HistoryEntryModelUnion]
 	Position        *HistoryPosition
 }
 
@@ -1183,6 +1204,8 @@ func (b *historyEntryBuilder) Meeting() *meetingBuilder {
 		},
 	}
 }
+
+// TODO: func (b *historyEntryBuilder) Model()
 
 func (b *historyEntryBuilder) Position() *historyPositionBuilder {
 	return &historyPositionBuilder{
@@ -1303,6 +1326,16 @@ func (r *Fetch) ImportPreview(ids ...int) *importPreviewBuilder {
 	}
 }
 
+type ListOfSpeakersContentObjectUnion interface {
+	isListOfSpeakersContentObjectUnion()
+}
+
+func (*Motion) isListOfSpeakersContentObjectUnion()           {}
+func (*MotionBlock) isListOfSpeakersContentObjectUnion()      {}
+func (*Assignment) isListOfSpeakersContentObjectUnion()       {}
+func (*Topic) isListOfSpeakersContentObjectUnion()            {}
+func (*MeetingMediafile) isListOfSpeakersContentObjectUnion() {}
+
 // ListOfSpeakers has all fields from list_of_speakers.
 type ListOfSpeakers struct {
 	Closed                           bool
@@ -1314,6 +1347,7 @@ type ListOfSpeakers struct {
 	SequentialNumber                 int
 	SpeakerIDs                       []int
 	StructureLevelListOfSpeakersIDs  []int
+	ContentObject                    *ListOfSpeakersContentObjectUnion
 	Meeting                          *Meeting
 	ProjectionList                   []Projection
 	SpeakerList                      []Speaker
@@ -1342,6 +1376,8 @@ func (b *listOfSpeakersBuilder) Preload(rel builderWrapperI) *listOfSpeakersBuil
 	b.builder.Preload(rel)
 	return b
 }
+
+// TODO: func (b *listOfSpeakersBuilder) ContentObject()
 
 func (b *listOfSpeakersBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
@@ -1399,6 +1435,13 @@ func (r *Fetch) ListOfSpeakers(ids ...int) *listOfSpeakersBuilder {
 	}
 }
 
+type MediafileOwnerUnion interface {
+	isMediafileOwnerUnion()
+}
+
+func (*Meeting) isMediafileOwnerUnion()      {}
+func (*Organization) isMediafileOwnerUnion() {}
+
 // Mediafile has all fields from mediafile.
 type Mediafile struct {
 	ChildIDs                            []int
@@ -1417,6 +1460,7 @@ type Mediafile struct {
 	Token                               string
 	ChildList                           []Mediafile
 	MeetingMediafileList                []MeetingMediafile
+	Owner                               *MediafileOwnerUnion
 	Parent                              *dsfetch.Maybe[Mediafile]
 	PublishedToMeetingsInOrganization   *dsfetch.Maybe[Organization]
 }
@@ -1472,6 +1516,8 @@ func (b *mediafileBuilder) MeetingMediafileList() *meetingMediafileBuilder {
 		},
 	}
 }
+
+// TODO: func (b *mediafileBuilder) Owner()
 
 func (b *mediafileBuilder) Parent() *mediafileBuilder {
 	return &mediafileBuilder{
@@ -5624,6 +5670,12 @@ func (r *Fetch) OrganizationTag(ids ...int) *organizationTagBuilder {
 	}
 }
 
+type PersonalNoteContentObjectUnion interface {
+	isPersonalNoteContentObjectUnion()
+}
+
+func (*Motion) isPersonalNoteContentObjectUnion() {}
+
 // PersonalNote has all fields from personal_note.
 type PersonalNote struct {
 	ContentObjectID string
@@ -5632,6 +5684,7 @@ type PersonalNote struct {
 	MeetingUserID   int
 	Note            string
 	Star            bool
+	ContentObject   *PersonalNoteContentObjectUnion
 	Meeting         *Meeting
 	MeetingUser     *MeetingUser
 }
@@ -5655,6 +5708,8 @@ func (b *personalNoteBuilder) Preload(rel builderWrapperI) *personalNoteBuilder 
 	b.builder.Preload(rel)
 	return b
 }
+
+// TODO: func (b *personalNoteBuilder) ContentObject()
 
 func (b *personalNoteBuilder) Meeting() *meetingBuilder {
 	return &meetingBuilder{
@@ -5749,6 +5804,24 @@ func (r *Fetch) PointOfOrderCategory(ids ...int) *pointOfOrderCategoryBuilder {
 	}
 }
 
+type PollConfigUnion interface {
+	isPollConfigUnion()
+}
+
+func (*PollConfigApproval) isPollConfigUnion()       {}
+func (*PollConfigSelection) isPollConfigUnion()      {}
+func (*PollConfigRatingScore) isPollConfigUnion()    {}
+func (*PollConfigRatingApproval) isPollConfigUnion() {}
+func (*PollConfigStvScottish) isPollConfigUnion()    {}
+
+type PollContentObjectUnion interface {
+	isPollContentObjectUnion()
+}
+
+func (*Motion) isPollContentObjectUnion()     {}
+func (*Assignment) isPollContentObjectUnion() {}
+func (*Topic) isPollContentObjectUnion()      {}
+
 // Poll has all fields from poll.
 type Poll struct {
 	AllowInvalid      bool
@@ -5771,6 +5844,8 @@ type Poll struct {
 	Visibility        string
 	VotedIDs          []int
 	BallotList        []PollBallot
+	Config            *PollConfigUnion
+	ContentObject     *PollContentObjectUnion
 	EntitledGroupList []Group
 	Meeting           *Meeting
 	OptionList        []PollOption
@@ -5822,6 +5897,10 @@ func (b *pollBuilder) BallotList() *pollBallotBuilder {
 		},
 	}
 }
+
+// TODO: func (b *pollBuilder) Config()
+
+// TODO: func (b *pollBuilder) ContentObject()
 
 func (b *pollBuilder) EntitledGroupList() *groupBuilder {
 	return &groupBuilder{
@@ -6282,6 +6361,22 @@ func (r *Fetch) PollOption(ids ...int) *pollOptionBuilder {
 	}
 }
 
+type ProjectionContentObjectUnion interface {
+	isProjectionContentObjectUnion()
+}
+
+func (*Meeting) isProjectionContentObjectUnion()            {}
+func (*Motion) isProjectionContentObjectUnion()             {}
+func (*MeetingMediafile) isProjectionContentObjectUnion()   {}
+func (*ListOfSpeakers) isProjectionContentObjectUnion()     {}
+func (*MotionBlock) isProjectionContentObjectUnion()        {}
+func (*Assignment) isProjectionContentObjectUnion()         {}
+func (*AgendaItem) isProjectionContentObjectUnion()         {}
+func (*Topic) isProjectionContentObjectUnion()              {}
+func (*Poll) isProjectionContentObjectUnion()               {}
+func (*ProjectorMessage) isProjectionContentObjectUnion()   {}
+func (*ProjectorCountdown) isProjectionContentObjectUnion() {}
+
 // Projection has all fields from projection.
 type Projection struct {
 	ContentObjectID    string
@@ -6294,6 +6389,7 @@ type Projection struct {
 	Stable             bool
 	Type               string
 	Weight             int
+	ContentObject      *ProjectionContentObjectUnion
 	CurrentProjector   *dsfetch.Maybe[Projector]
 	HistoryProjector   *dsfetch.Maybe[Projector]
 	Meeting            *Meeting
@@ -6323,6 +6419,8 @@ func (b *projectionBuilder) Preload(rel builderWrapperI) *projectionBuilder {
 	b.builder.Preload(rel)
 	return b
 }
+
+// TODO: func (b *projectionBuilder) ContentObject()
 
 func (b *projectionBuilder) CurrentProjector() *projectorBuilder {
 	return &projectorBuilder{


### PR DESCRIPTION
This PR adds support for preloading of generic relations. This is mainly needed for preloading poll configs in the projector service. 
Therefore those kind of relations come with the limitation that chaining is not supported. Also lists are not supported. 
With those changes generic list relations should also be easy to add. However - I do not see any use case for that right now. 